### PR TITLE
Renamed occurrences of 'mailx' to 'murmur'; add tagging restrictions 

### DIFF
--- a/browser/templates/base.html
+++ b/browser/templates/base.html
@@ -41,7 +41,7 @@
 
 <body>
 	
-<div id="mailx-header" class="navbar navbar-default navbar-fixed-top navlook" role="navigation">
+<div id="murmur-header" class="navbar navbar-default navbar-fixed-top navlook" role="navigation">
       <div class="container">
         <div class="navbar-header">
         	<button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".navbar-collapse">

--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -39,12 +39,12 @@
 	<span class="strong">Attachment Policy : </span> <br />
 	{% if group_info.allow_attachments %}
 		<input type="radio" name="attach" value="yes-attach" id="rdo-attach-create-group" checked> Allow Attachments<br />
-		<span class="italic-small">All members of the group can post attachments to the list. Size of attachment cannot exceed 1MB. We currently only support images and pdfs.</span>
+		<span class="italic-small">All members of the group can post attachments to the list. Size of attachment cannot exceed 3MB. We currently only support a few filetypes (jpg, pdf, ppt, doc, txt, png).</span>
 		<input type="radio" name="attach" value="no-attach" id="rdo-noattach-create-group"> No Attachments Allowed<br />
 		<span class="italic-small">Users will not be able to post attachments to the list.</span><br />
 	{% else %}
 		<input type="radio" name="attach" value="yes-attach" id="rdo-attach-create-group"> Allow Attachments<br />
-		<span class="italic-small">All members of the group can post attachments to the list. Size of attachment cannot exceed 1MB. We currently only support images and pdfs.</span>
+		<span class="italic-small">All members of the group can post attachments to the list. Size of attachment cannot exceed 3MB. We currently only support a few filetypes (jpg, pdf, ppt, doc, txt, png).</span>
 		<input type="radio" name="attach" value="no-attach" id="rdo-noattach-create-group" checked> No Attachments Allowed<br />
 		<span class="italic-small">Users will not be able to post attachments to the list.</span><br />
 	{% endif %}

--- a/config/logging.conf
+++ b/config/logging.conf
@@ -24,7 +24,7 @@ class=FileHandler
 #class=WatchedFileHandler
 level=DEBUG
 formatter=defaultFormatter
-args=("logs/mailx_smtp.log",)
+args=("logs/murmur_smtp.log",)
 
 [formatter_defaultFormatter]
 format=%(asctime)s - %(name)s - %(levelname)s - %(message)s

--- a/engine/constants.py
+++ b/engine/constants.py
@@ -19,6 +19,18 @@ msg_code={
 	'UNKNOWN_ERROR': 'Unknown',
 }
 
+def is_number(tag): 
+	try:
+		int(tag[1:])
+		return True
+	except ValueError:
+		return False
+
 def extract_hash_tags(s):
 	s = re.sub("<.*?>", " ", s)
-	return set(re.sub(r'\W+', '', part).lower() for part in s.split() if part.startswith('#'))
+	tags = [re.sub(r'\W+', '', part).lower() for part in s.split() if part.startswith('#') and not is_number(part)]
+	first_three = set()
+	for t in tags:
+		first_three.add(t)
+		if len(first_three) == 3: break
+	return first_three

--- a/http_handler/settings.py
+++ b/http_handler/settings.py
@@ -7,8 +7,8 @@ import django
 DJANGO_ROOT = os.path.dirname(os.path.realpath(django.__file__))
 SITE_ROOT = os.path.dirname(os.path.realpath(__file__))
 
-_ENV_FILE_PATH = '/opt/mailx/env'
-_DEBUG_FILE_PATH = '/opt/mailx/debug'
+_ENV_FILE_PATH = '/opt/murmur/env'
+_DEBUG_FILE_PATH = '/opt/murmur/debug'
 
 def _get_env():
     f = open(_ENV_FILE_PATH)

--- a/http_handler/settings.py
+++ b/http_handler/settings.py
@@ -1,4 +1,4 @@
-# Django settings for mailx project.
+# Django settings for murmur project.
 
 import os
 import django

--- a/http_handler/static/css/base.css
+++ b/http_handler/static/css/base.css
@@ -335,7 +335,7 @@ textarea {
 }
 
 
-#mailx-header ul {
+#murmur-header ul {
     list-style-type: none;
     padding-left: 0px;
     margin-left: 0px;
@@ -399,7 +399,7 @@ textarea {
 	cursor: pointer;
 }
 
-#mailx-header li {
+#murmur-header li {
 	margin-left: 10px;
 	margin-right: 10px;
 }

--- a/http_handler/wsgi.py
+++ b/http_handler/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for mailx project.
+WSGI config for murmur project.
 
 This module contains the WSGI application used by Django's development server
 and any production WSGI deployments. It should expose a module-level variable

--- a/schema/models.py
+++ b/schema/models.py
@@ -20,7 +20,7 @@ class Post(models.Model):
 		return '%s %s' % (self.author.email, self.subject)
 	
 	class Meta:
-		db_table = "mailx_posts"
+		db_table = "murmur_posts"
 		ordering = ["timestamp"]
 
 
@@ -34,7 +34,7 @@ class Thread(models.Model):
 		return '%s in %s' % (self.id, self.group)
 	
 	class Meta:
-		db_table = "mailx_threads"
+		db_table = "murmur_threads"
 		ordering = ["-timestamp"]
 
 
@@ -102,7 +102,7 @@ class MemberGroup(models.Model):
 		return '%s - %s' % (self.member.email, self.group.name)
 
 	class Meta:
-		db_table = "mailx_membergroups"
+		db_table = "murmur_membergroups"
 		unique_together = ("member", "group")
 	
 
@@ -121,7 +121,7 @@ class Group(models.Model):
 		return self.name
 
 	class Meta:
-		db_table = "mailx_groups"
+		db_table = "murmur_groups"
 
 
 
@@ -208,7 +208,7 @@ class Following(models.Model):
 		return '%s follows Thread: %s' % (self.user.email, self.thread.id)
 
 	class Meta:
-		db_table = "mailx_following"
+		db_table = "murmur_following"
 
 
 class Mute(models.Model):
@@ -221,7 +221,7 @@ class Mute(models.Model):
 		return '%s mutes Thread: %s' % (self.user.email, self.thread.id)
 
 	class Meta:
-		db_table = "mailx_mute"
+		db_table = "murmur_mute"
 
 class Upvote(models.Model):
 	id = models.AutoField(primary_key=True)
@@ -233,6 +233,6 @@ class Upvote(models.Model):
 		return '%s likes Post %s' % (self.user.email, self.post.id)
 
 	class Meta:
-		db_table = "mailx_likes"
+		db_table = "murmur_likes"
 
 

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -180,7 +180,7 @@ def handle_post(message, address=None, host=None):
 			relay.deliver(mail, To = ADMIN_EMAILS)
 			return
 		
-		if message['Subject'][0:4] != "Re: ":
+		if message['Subject'][0:4].lower() != "re: ":
 			orig_message = message['Subject'].strip()
 		else:
 			orig_message = re.sub("\[.*?\]", "", message['Subject'][4:]).strip()
@@ -204,7 +204,7 @@ def handle_post(message, address=None, host=None):
 			relay.deliver(mail, To = ADMIN_EMAILS)
 			return
 	
-		if message['Subject'][0:4] == "Re: ":
+		if message['Subject'][0:4].lower() == "re: ":
 			if 'html' in msg_text:
 				msg_text['html'] = remove_html_ps(msg_text['html'])
 			if 'plain' in msg_text:
@@ -223,7 +223,7 @@ def handle_post(message, address=None, host=None):
 			relay.deliver(mail, To = ADMIN_EMAILS)
 			return
 		
-		if message['Subject'][0:4] == "Re: ":
+		if message['Subject'][0:4].lower() == "re: ":
 			res = insert_reply(group_name, "Re: " + orig_message, msg_text['html'], user)
 		else:
 			res = insert_post(group_name, orig_message, msg_text['html'], user)
@@ -234,7 +234,7 @@ def handle_post(message, address=None, host=None):
 			relay.deliver(mail, To = ADMIN_EMAILS)
 			return
 	
-		if message['Subject'][0:4] != "Re: ":
+		if message['Subject'][0:4].lower() != "re: ":
 			subj_tag = ''
 			for tag in res['tags']:
 				subj_tag += '[%s]' % tag['name']

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -12,7 +12,7 @@ from django.db.utils import OperationalError
 import django.db
 
 '''
-MailX Mail Interface Handler
+Murmur Mail Interface Handler
 
 @author: Anant Bhardwaj
 @date: Oct 20, 2012

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -55,8 +55,10 @@ RESERVED = ['+create', '+activate', '+deactivate', '+subscribe', '+unsubscribe',
 
 relay_mailer = Relay(host=relay_config['host'], port=relay_config['port'], debug=1)
 
-ALLOWED_MIMETYPES = ["image/jpeg", "image/bmp", "image/gif", "image/png", "application/pdf"]
-MAX_ATTACHMENT_SIZE = 1000000
+ALLOWED_MIMETYPES = ["image/jpeg", "image/bmp", "image/gif", "image/png", "application/pdf", "application/mspowerpoint",
+					"application/x-mspowerpoint", "application/powerpoint", "application/vnd.ms-powerpoint",
+					"application/msword", "text/plain"]
+MAX_ATTACHMENT_SIZE = 3000000
 
 def setup_post(From, Subject, group_name):
 	

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -7,7 +7,7 @@ from schema.models import Group, MemberGroup, Thread, Following, Mute
 
 
 '''
-MailX Mail Utils and Constants
+Murmur Mail Utils and Constants
 
 @author: Anant Bhardwaj
 @date: Oct 20, 2012


### PR DESCRIPTION
Mostly pretty small changes. (I don't know how do-able it is to rename existing DB tables, so if you don't want that change let me know and I'll make a new pull request without it.) Only places I'm still finding "mailx" with grep are the readme and celeryconfig.py 