### PR TITLE
Send "unsubscribe" to unsubscribe

### DIFF
--- a/browser/templates/subscribe.html
+++ b/browser/templates/subscribe.html
@@ -10,6 +10,19 @@
 	
 	{% if res.status %}
 		You've {{ type }} the group "{{ group_name }}".
+		<BR>
+		<BR>
+		{% if type == 'unsubscribed from' %}
+		<form action="/subscribe_get?">
+			<input type='hidden' name='group_name' value={{group_name}}>
+    		<input type="submit" value="Re-subscribe">
+		</form>
+		{% else %}
+		<form action="/unsubscribe_get?">
+			<input type='hidden' name='group_name' value={{group_name}}>
+    		<input type="submit" value="Unsubscribe">
+		</form>
+		{% endif %}
 	{% else %}
 		Sorry, there was an error: {{ res.code }}.
 	{% endif %}
@@ -19,10 +32,5 @@
 </div>
 
 {% endblock %}
-
-{% block customjs %}
-{% endblock %}
-
-
 
 

--- a/browser/templates/subscribe.html
+++ b/browser/templates/subscribe.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block customcss %}
+{% endblock %}
+
+{% block content %}
+
+<div class="container">
+  <div class="group-container">
+	
+	{% if res.status %}
+		You've {{ type }} the group "{{ group_name }}".
+	{% else %}
+		Sorry, there was an error: {{ res.code }}.
+	{% endif %}
+	<BR>
+	<BR>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block customjs %}
+{% endblock %}
+
+
+
+

--- a/browser/views.py
+++ b/browser/views.py
@@ -856,13 +856,42 @@ def unupvote(request):
 		logging.debug(e)
 		return HttpResponse(request_error, content_type="application/json")
 
+
+@render_to('subscribe.html')
+@login_required
+def unsubscribe_get(request):
+	if request.user.is_authenticated():
+		user = get_object_or_404(UserProfile, email=request.user.email)
+		res = engine.main.unsubscribe_group(request.GET.get('group_name'), user)
+		groups = Group.objects.filter(membergroup__member=user).values("name")
+		return {'res':res, 'type': 'unsubscribed from', 'user': request.user, 'group_name' : request.GET.get('group_name'),
+		'groups' : groups, 'active_group': None}
+	else:
+		return redirect(global_settings.LOGIN_URL + '?next=/unsubscribe_get?group_name=' + request.GET.get('group_name'))
+
+@render_to('subscribe.html')
+@login_required
+def subscribe_get(request):
+	if request.user.is_authenticated():
+		user = get_object_or_404(UserProfile, email=request.user.email)
+		group_name = request.GET.get('group_name')
+		res = engine.main.subscribe_group(group_name, user)
+		groups = Group.objects.filter(membergroup__member=user).values("name")
+		if res['status']:
+			active_group = load_groups(request, groups, user, group_name=group_name)
+		else:
+			active_group = None
+		return {'res':res, 'type': 'subscribed to', 'user': request.user, 'groups': groups,
+		'active_group': active_group, 'group_name' : group_name}
+	else:
+		return redirect(global_settings.LOGIN_URL + '?next=/subscribe_get?group_name=' + request.GET.get('group_name'))
+
 @render_to("upvote.html")
 @login_required
 def upvote_get(request):
 	if request.user.is_authenticated():
 		user = get_object_or_404(UserProfile, email=request.user.email)
 		groups = Group.objects.filter(membergroup__member=user).values("name")
-
 		post_id = request.GET.get('post_id')
 		res = engine.main.upvote(post_id, user=user)
 		active_group = load_groups(request, groups, user, group_name=res['group_name'])

--- a/browser/views.py
+++ b/browser/views.py
@@ -864,8 +864,11 @@ def unsubscribe_get(request):
 		user = get_object_or_404(UserProfile, email=request.user.email)
 		res = engine.main.unsubscribe_group(request.GET.get('group_name'), user)
 		groups = Group.objects.filter(membergroup__member=user).values("name")
+		active_group = {'name':'No Groups Yet'}
+		if len(groups) > 0:
+			active_group = load_groups(request, groups, user, group_name=groups[0]['name'])
 		return {'res':res, 'type': 'unsubscribed from', 'user': request.user, 'group_name' : request.GET.get('group_name'),
-		'groups' : groups, 'active_group': None}
+		'groups' : groups, 'active_group': active_group}
 	else:
 		return redirect(global_settings.LOGIN_URL + '?next=/unsubscribe_get?group_name=' + request.GET.get('group_name'))
 
@@ -880,7 +883,9 @@ def subscribe_get(request):
 		if res['status']:
 			active_group = load_groups(request, groups, user, group_name=group_name)
 		else:
-			active_group = None
+			active_group = {'name':'No Groups Yet'}
+			if len(groups) > 0:
+				active_group = load_groups(request, groups, user, group_name=groups[0]['name'])
 		return {'res':res, 'type': 'subscribed to', 'user': request.user, 'groups': groups,
 		'active_group': active_group, 'group_name' : group_name}
 	else:

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -72,8 +72,8 @@ urlpatterns = patterns('',
      url(r'^mute', 'browser.views.mute_thread_get'),
      url(r'^unmute', 'browser.views.unmute_thread_get'),
      
-
-
+     url(r'^unsubscribe_get', 'browser.views.unsubscribe_get'),
+     url(r'^subscribe_get', 'browser.views.subscribe_get'),
 
      
     #override the registration default urls - bug with django 1.6

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -201,13 +201,6 @@ def handle_post(message, address=None, host=None):
 		
 		email_message = email.message_from_string(str(message))
 		msg_text = get_body(email_message)
-
-		if msg_text['plain'].startswith('unsubscribe\n'):
-			unsubscribe(message, group_name = group_name, host = HOST)
-			return
-		elif msg_text['plain'].startswith('subscribe\n'):
-			subscribe(message, group_name = group_name, host = HOST)
-			return
 	
 		attachments = get_attachments(email_message)
 		if len(attachments['attachments']) > 0:
@@ -235,6 +228,13 @@ def handle_post(message, address=None, host=None):
 			msg_text['html'] = markdown(msg_text['plain'])
 		if 'plain' not in msg_text or msg_text['plain'] == '':
 			msg_text['plain'] = html2text(msg_text['html'])
+
+		if msg_text['plain'].startswith('unsubscribe\n'):
+			unsubscribe(message, group_name = group_name, host = HOST)
+			return
+		elif msg_text['plain'].startswith('subscribe\n'):
+			subscribe(message, group_name = group_name, host = HOST)
+			return
 		
 		try:
 			user = UserProfile.objects.get(email=addr)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -159,7 +159,7 @@ def info(message, group_name=None, host=None):
 def handle_post(message, address=None, host=None):
 	if '+' in address and '__' in address:
 		return
-	
+
 	try:
 		#does this fix the MySQL has gone away erro?
 		django.db.close_connection()
@@ -187,6 +187,10 @@ def handle_post(message, address=None, host=None):
 		
 		email_message = email.message_from_string(str(message))
 		msg_text = get_body(email_message)
+
+		if msg_text['plain'].lower() == 'unsubscribe':
+			unsubscribe(message, group_name, host)
+			return
 	
 		attachments = get_attachments(email_message)
 		if len(attachments['attachments']) > 0:

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -114,7 +114,8 @@ def unsubscribe(message, group_name=None, host=None):
 	group = None
 	group_name = group_name.lower()
 	name, addr = parseaddr(message['from'].lower())
-	res = unsubscribe_group(group_name, addr)
+	user = UserProfile.objects.get(email=addr)
+	res = unsubscribe_group(group_name, user)
 	subject = "Un-subscribe -- Success"
 	body = "You are now un-subscribed from: %s@%s" %(group_name, host)
 	if(not res['status']):

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -129,12 +129,14 @@ def unsubscribe(message, group_name=None, host=None):
 		relay.deliver(mail, To = ADMIN_EMAILS)
 		return
 	res = unsubscribe_group(group_name, user)
-	subject = "Un-subscribe -- Success"
-	body = "You are now un-subscribed from: %s@%s" %(group_name, host)
+	subject = "Unsubscribe -- Success"
+	body = "You are now unsubscribed from: %s@%s." %(group_name, host)
+	body += " To resubscribe, reply to this email."
 	if(not res['status']):
-		subject = "Un-subscribe -- Error"
+		subject = "Unsubscribe -- Error"
 		body = "Error Message: %s" %(res['code'])
 	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
+	mail['Reply-To'] = '%s+subscribe@%s' %(group_name, host)
 	relay.deliver(mail)
 
 
@@ -229,10 +231,10 @@ def handle_post(message, address=None, host=None):
 		if 'plain' not in msg_text or msg_text['plain'] == '':
 			msg_text['plain'] = html2text(msg_text['html'])
 
-		if msg_text['plain'].startswith('unsubscribe\n'):
+		if msg_text['plain'].startswith('unsubscribe\n') or msg_text['plain'] == 'unsubscribe':
 			unsubscribe(message, group_name = group_name, host = HOST)
 			return
-		elif msg_text['plain'].startswith('subscribe\n'):
+		elif msg_text['plain'].startswith('subscribe\n') or msg_text['plain'] == 'subscribe':
 			subscribe(message, group_name = group_name, host = HOST)
 			return
 		

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -103,6 +103,20 @@ def subscribe(message, group_name=None, host=None):
 		relay.deliver(mail, To = addr)
 		relay.deliver(mail, To = ADMIN_EMAILS)
 		return
+	try:
+		group = Group.objects.get(name=group_name)
+	except Group.DoesNotExist:
+		mail = create_error_email(group_name, 'The group' + group_name + 'does not exist.')
+		relay.deliver(mail, To = addr)
+		relay.deliver(mail, To = ADMIN_EMAILS)
+		return
+
+	if not group.public:
+		mail = create_error_email(group_name, 'The group' + group_name + 'is private. Ask the admin of the group to add you.')
+		relay.deliver(mail, To = addr)
+		relay.deliver(mail, To = ADMIN_EMAILS)
+		return
+
 	res = subscribe_group(group_name, user)
 	subject = "Subscribe -- Success"
 	body = "You are now subscribed to: %s@%s" %(group_name, host)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -202,12 +202,12 @@ def handle_post(message, address=None, host=None):
 		email_message = email.message_from_string(str(message))
 		msg_text = get_body(email_message)
 
-		if msg_text['plain'] == 'unsubscribe\n':
+		if msg_text['plain'].startswith('unsubscribe\n'):
 			unsubscribe(message, group_name = group_name, host = HOST)
 			return
-		elif msg_text['plain'] == 'subscribe\n':
+		elif msg_text['plain'].startswith('subscribe\n'):
 			subscribe(message, group_name = group_name, host = HOST)
-
+			return
 	
 		attachments = get_attachments(email_message)
 		if len(attachments['attachments']) > 0:

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -112,7 +112,7 @@ def subscribe(message, group_name=None, host=None):
 		return
 
 	if not group.public:
-		mail = create_error_email(group_name, 'The group' + group_name + 'is private. Ask the admin of the group to add you.')
+		mail = create_error_email(group_name, 'The group ' + group_name + ' is private. Ask the admin of the group to add you.')
 		relay.deliver(mail, To = addr)
 		relay.deliver(mail, To = ADMIN_EMAILS)
 		return

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -188,9 +188,10 @@ def handle_post(message, address=None, host=None):
 		email_message = email.message_from_string(str(message))
 		msg_text = get_body(email_message)
 
-		if msg_text['plain'].lower() == 'unsubscribe':
-			unsubscribe(message, group_name, host)
+		if msg_text['plain'] == 'unsubscribe\n':
+			unsubscribe(message, group_name = group_name, host = HOST)
 			return
+
 	
 		attachments = get_attachments(email_message)
 		if len(attachments['attachments']) > 0:

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -345,7 +345,7 @@ def plain_ps(group, thread, post_id, membergroup, following, muting, tag_followi
 			content += 'You\'re currently muting this thread. Un-Mute thread<%s>.\n' % (unmute_addr)
 		else:
 			if tag_muting.count() > 0:
-			`	tag_names = [m.tag.name for m in tag_muting]
+				tag_names = [m.tag.name for m in tag_muting]
 				if len(tag_names) > 1:
 					n_str = ', '.join(tag_names)
 					content += 'You\'re currently muting the tags %s. \n' % (n_str)

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -307,7 +307,7 @@ def html_ps(group, thread, post_id, membergroup, following, muting, tag_followin
 		content += "<BR><BR>You are set to receive only the 1st email from this group, except for the threads you follow. <BR><a href=\"%s\">Change your settings</a>" % (addr)
 
 	unsubscribe_addr = UNSUBSCRIBE_ADDR % (HOST, group.name)
-	content += '<a href=\"%s\">Unsubscribe from this group</a>' % unsubscribe_addr
+	content += ' | ''<a href=\"%s\">Unsubscribe from this group</a>' % unsubscribe_addr
 
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
 	return body
@@ -345,7 +345,7 @@ def plain_ps(group, thread, post_id, membergroup, following, muting, tag_followi
 			content += 'You\'re currently muting this thread. Un-Mute thread<%s>.\n' % (unmute_addr)
 		else:
 			if tag_muting.count() > 0:
-				tag_names = [m.tag.name for m in tag_muting]
+			`	tag_names = [m.tag.name for m in tag_muting]
 				if len(tag_names) > 1:
 					n_str = ', '.join(tag_names)
 					content += 'You\'re currently muting the tags %s. \n' % (n_str)

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -44,6 +44,9 @@ UNMUTE_ADDR = 'http://%s/unmute?tid=' % (HOST)
 
 UPVOTE_ADDR = 'http://%s/upvote_get?tid=%s&post_id=%s' 
 
+SUBSCRIBE_ADDR = 'http://%s/subscribe_get?group_name=%s'
+UNSUBSCRIBE_ADDR = 'http://%s/unsubscribe_get?group_name=%s'
+
 EDIT_SETTINGS_ADDR = 'http://%s/groups/%s/edit_my_settings'
 
 PERMALINK_POST = 'http://%s/thread?tid=%s&post_id=%s'
@@ -303,7 +306,8 @@ def html_ps(group, thread, post_id, membergroup, following, muting, tag_followin
 	else:
 		content += "<BR><BR>You are set to receive only the 1st email from this group, except for the threads you follow. <BR><a href=\"%s\">Change your settings</a>" % (addr)
 
-		
+	unsubscribe_addr = UNSUBSCRIBE_ADDR % (HOST, group.name)
+	content += '<a href=\"%s\">Unsubscribe from this group</a>' % unsubscribe_addr
 
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
 	return body
@@ -360,6 +364,8 @@ def plain_ps(group, thread, post_id, membergroup, following, muting, tag_followi
 	else:
 		content += "\n\nYou are set to receive only the 1st email from this group, except for the threads you follow. \nChange your settings<%s>" % (addr)
 
+	unsubscribe_addr = UNSUBSCRIBE_ADDR % (HOST, group.name)
+	content += '\n\nUnsubscribe from this group<%s>' % unsubscribe_addr
 		
 	body = '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
 	

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -307,7 +307,7 @@ def html_ps(group, thread, post_id, membergroup, following, muting, tag_followin
 		content += "<BR><BR>You are set to receive only the 1st email from this group, except for the threads you follow. <BR><a href=\"%s\">Change your settings</a>" % (addr)
 
 	unsubscribe_addr = UNSUBSCRIBE_ADDR % (HOST, group.name)
-	content += ' | ''<a href=\"%s\">Unsubscribe from this group</a>' % unsubscribe_addr
+	content += ' | ''<a href=\"%s\">Unsubscribe</a>' % unsubscribe_addr
 
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
 	return body
@@ -365,7 +365,7 @@ def plain_ps(group, thread, post_id, membergroup, following, muting, tag_followi
 		content += "\n\nYou are set to receive only the 1st email from this group, except for the threads you follow. \nChange your settings<%s>" % (addr)
 
 	unsubscribe_addr = UNSUBSCRIBE_ADDR % (HOST, group.name)
-	content += '\n\nUnsubscribe from this group<%s>' % unsubscribe_addr
+	content += '\n\nUnsubscribe<%s>' % unsubscribe_addr
 		
 	body = '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
 	


### PR DESCRIPTION
If you send a message that starts with "subscribe" or "unsubscribe" followed by the newline character, the message handling will be transferred to the relevant route and you will subscribe/unsubscribe to the group. Fixes issue #51 

Those routes were not actually working (the function calls passed in the email address rather than the user object) so I fixed them. I ended up just copy-pasting in the try/except from another part of main.py. From what I can tell, in every part of the code where subscribe_group or unsubscribe_group is called, the call is preceded by a similar try/except (or get_object_or_404) to get the user via their email address. It might make sense to have the functions just take in the email address rather than user, and if the user is not found the function can return an appropriate error message. They already do some error handling for group not found, anyway.