### PR TITLE
gmail quoting issue

### DIFF
--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -28,7 +28,7 @@ UPVOTE_SUFFIX = '__upvote__'
 DOWNVOTE_SUFFIX = '__downvote__'
 FETCH_SUFFIX = '__fetch__'
 
-ADMIN_EMAILS = ['axz@mit.edu']
+ADMIN_EMAILS = ['axz@mit.edu', 'kmahar@mit.edu']
 
 FOLLOW_ADDR = 'http://%s/follow?tid=' % (HOST)
 UNFOLLOW_ADDR = 'http://%s/unfollow?tid=' % (HOST)


### PR DESCRIPTION
created MurmurMIMEPart to make all text/html encoded using quoted-printable; copied to_message from lamson/encoding.py and changed it to use MurmurMIMEPart