### PR TITLE
hide group members for non-admins

### DIFF
--- a/browser/templates/group_page.html
+++ b/browser/templates/group_page.html
@@ -93,7 +93,7 @@
 			</div>
 			<br />
 			<hr />
-
+			{% if group_info.admin %}
 			<h3>Members List</h3> 
 			{% if group_info.admin %}
 				<button type="button" id="btn-add-members">Add Members</button>
@@ -193,7 +193,7 @@
 					{% endfor %}
 				</tbody>
 			</table>	
-
+			{% endif %}
 
 
   </div>

--- a/browser/templates/groups.html
+++ b/browser/templates/groups.html
@@ -33,6 +33,7 @@
 		<button type="button" id="btn-delete-group">Delete Group</button>
 	</div>
 	<br />
+	<div id='members-list-area' style='display:none;'>
 	<h3>Members List</h3> 
 	<hr />
 	<button type="button" id="btn-add-members">Add Members</button>
@@ -41,7 +42,7 @@
 	<!--	<button type="button" id="btn-undo-admin">Revoke Admin Rights</button> -->
 	<button type="button" id="btn-set-mod">Set as Moderator</button>
 	<!--	<button type="button" id="btn-undo-mod">Revoke Moderator Rights</button> -->
-
+	
 	<table id="members-table" class="display" cellspacing="0" width="100%">
 		<thead>
 			<tr>
@@ -52,6 +53,7 @@
 			</tr>
 		</thead>
 	</table>	
+	</div>
 </div>	
 </div>
 </div>

--- a/http_handler/static/javascript/main.js
+++ b/http_handler/static/javascript/main.js
@@ -591,6 +591,7 @@ $(document).ready(function(){
 	}
 
 	function populate_members_table(res){
+
 		members_table.fnClearTable();
 		current_group_name = res.members[0].group_name;
 		for(var i = 0; i< res.members.length; i++){
@@ -656,12 +657,14 @@ $(document).ready(function(){
 			btn_set_admin.hide();
 			btn_set_mod.hide();
 			btn_delete_group.hide();
+			$('#members-list-area').css('display', 'none');
 		}
 		else{
 			btn_delete_members.show();
 			btn_set_admin.show();
 			btn_set_mod.show();
 			btn_delete_group.show();
+			$('#members-list-area').css('display', '');
 		}
 		};
 


### PR DESCRIPTION
as per @karger 's request the members list is not shown to non-admins. haven't done to show admin contact info yet, waiting until we decide on that. but this helps with the privacy concern for now anyway