### PR TITLE
list forwarding fixes and de-duplication

### DIFF
--- a/browser/templates/group_page.html
+++ b/browser/templates/group_page.html
@@ -195,6 +195,7 @@
 									<th>Added</th>
 									<th>Can Post</th>
 									<th>Can Receive</th>
+									<th>List URL</th>
 								</tr>
 							</thead>
 							
@@ -206,6 +207,7 @@
 									<th>Added</th>
 									<th>Can Post</th>
 									<th>Can Receive</th>
+									<th>List URL</th>
 								{% endif %}
 							</tr>
 							</tfoot>
@@ -226,6 +228,11 @@
 											<th>
 												{% if l.can_receive %}
 													<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+												{% endif %}
+											</th>
+											<th>
+												{% if l.url != None %}
+												{{ l.url }}
 												{% endif %}
 											</th>
 										{% endif %}

--- a/browser/templates/group_page.html
+++ b/browser/templates/group_page.html
@@ -230,11 +230,13 @@
 													<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
 												{% endif %}
 											</th>
-											<th>
+											
+											<td>
 												{% if l.url != None %}
-												{{ l.url }}
+													<a href=//{{l.url}}>{{ l.url }}</a>
 												{% endif %}
-											</th>
+											</td>
+											
 										{% endif %}
 									</tr>
 								{% endfor %}

--- a/engine/main.py
+++ b/engine/main.py
@@ -728,7 +728,7 @@ def load_thread(t, user=None, member=None):
 					'id': str(p.id),
 					'msg_id': p.msg_id, 
 					'thread_id': p.thread_id, 
-					'from': p.poster.email, 
+					'from': p.poster_email, 
 					'likes': post_likes,
 					'to': p.group.name,
 					'liked': user_liked,

--- a/engine/main.py
+++ b/engine/main.py
@@ -807,8 +807,6 @@ def _create_post(group, subject, message_text, user, sender_addr, msg_id, forwar
 	thread.subject = stripped_subj
 	thread.group = group
 	thread.save()
-
-	#msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
 	
 	p = Post(msg_id=msg_id, author=user, poster_email = sender_addr, forwarding_list = forwarding_list, 
 			subject=stripped_subj, post=message_text, group=group, thread=thread)
@@ -981,8 +979,6 @@ def insert_reply(group_name, subject, message_text, user, sender_addr, msg_id, f
 				thread.save()
 			
 			tag_objs = Tag.objects.filter(tagthread__thread=thread)
-			
-			#msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
 			
 			try:
 				message_text = message_text.decode("utf-8")

--- a/engine/main.py
+++ b/engine/main.py
@@ -728,7 +728,7 @@ def load_thread(t, user=None, member=None):
 					'id': str(p.id),
 					'msg_id': p.msg_id, 
 					'thread_id': p.thread_id, 
-					'from': p.author.email, 
+					'from': p.poster.email, 
 					'likes': post_likes,
 					'to': p.group.name,
 					'liked': user_liked,
@@ -792,7 +792,7 @@ def _create_tag(group, thread, name):
 		t.save()
 	tagthread,_ = TagThread.objects.get_or_create(thread=thread, tag=t)
 
-def _create_post(group, subject, message_text, user, sender_addr, forwarding_list=None):
+def _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=None):
 
 	try:
 		message_text = message_text.decode("utf-8")
@@ -808,7 +808,7 @@ def _create_post(group, subject, message_text, user, sender_addr, forwarding_lis
 	thread.group = group
 	thread.save()
 
-	msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
+	#msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
 	
 	p = Post(msg_id=msg_id, author=user, poster_email = sender_addr, forwarding_list = forwarding_list, 
 			subject=stripped_subj, post=message_text, group=group, thread=thread)
@@ -855,8 +855,8 @@ def insert_post_web(group_name, subject, message_text, user):
 		group = Group.objects.get(name=group_name)
 		user_member = MemberGroup.objects.filter(group=group, member=user)
 		if user_member.exists():
-
-			p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, user.email)
+			msg_id = base64.b64encode(user.email + str(datetime.datetime.now())).lower() + '@' + BASE_URL
+			p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, user.email, msg_id)
 			res['status'] = True
 			
 			res['member_group'] = {'no_emails': user_member[0].no_emails, 
@@ -904,7 +904,7 @@ def insert_post_web(group_name, subject, message_text, user):
 	return res
 
 
-def insert_post(group_name, subject, message_text, user, sender_addr, forwarding_list=None):
+def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, forwarding_list=None):
 	res = {'status':False}
 	thread = None
 	try:
@@ -924,7 +924,7 @@ def insert_post(group_name, subject, message_text, user, sender_addr, forwarding
 		# 3) it's a post by someone who doesn't use Murmur, via a list that fwds to this group. 
 		# _create_post will check which of user and forwarding list are None and post appropriately. 
 
-		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, forwarding_list=forwarding_list)
+		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=forwarding_list)
 		res['status'] = True
 		res['post_id'] = p.id
 		res['msg_id'] = p.msg_id
@@ -948,7 +948,7 @@ def insert_post(group_name, subject, message_text, user, sender_addr, forwarding
 	
 
 
-def insert_reply(group_name, subject, message_text, user, sender_addr, forwarding_list=None, thread_id=None):
+def insert_reply(group_name, subject, message_text, user, sender_addr, msg_id, forwarding_list=None, thread_id=None):
 	res = {'status':False}
 	try:
 		group = Group.objects.get(name=group_name)
@@ -982,7 +982,7 @@ def insert_reply(group_name, subject, message_text, user, sender_addr, forwardin
 			
 			tag_objs = Tag.objects.filter(tagthread__thread=thread)
 			
-			msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
+			#msg_id = base64.b64encode(sender_addr + str(datetime.datetime.now())).lower() + '@' + BASE_URL
 			
 			try:
 				message_text = message_text.decode("utf-8")

--- a/engine/main.py
+++ b/engine/main.py
@@ -80,7 +80,8 @@ def group_info_page(user, group_name):
 						'email' : l.email,
 						'can_post' : l.can_post,
 						'can_receive' : l.can_receive,
-						'added': l.timestamp
+						'added': l.timestamp,
+						'url' : l.url
 						}
 			res['lists'].append(list_obj)
 

--- a/http_handler/static/javascript/group_page.js
+++ b/http_handler/static/javascript/group_page.js
@@ -25,7 +25,7 @@ $(document).ready(function(){
 			"aoColumns": [ { 'bSortable': false}, null, null, null, null]
 		}),
 			lists_table = $('#lists-table').dataTable({
-			"aoColumns": [ { 'bSortable': false}, null, null, null, null]
+			"aoColumns": [ { 'bSortable': false}, null, null, null, null, null]
 		});
 
 	} else {

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ python-daemon==1.6.1
 python-modargs==1.7
 six==1.8.0
 wsgiref==0.1.2
+pytz==2016.7

--- a/schema/models.py
+++ b/schema/models.py
@@ -16,6 +16,12 @@ class Post(models.Model):
 	reply_to = models.ForeignKey('self', blank=False, null = True, related_name="replies")
 	timestamp = models.DateTimeField(auto_now=True)
 	forwarding_list = models.ForeignKey('ForwardingList', null=True)
+	# a post's author is the Murmur user (if any) who wrote the post.
+	# a post's poster_email is the email address of the user who originally
+	# wrote the post. so if author is not null, author.email = poster_email.
+	# if the author is null, then the person who wrote the message isn't actually
+	# a member of this group on Murmur, and it was likely received via a list that
+	# fwds to this Murmur group
 	poster_email = models.EmailField(max_length=255, null=True)
 
 	def __unicode__(self):

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -256,6 +256,11 @@ def handle_post(message, address=None, host=None):
 			logging.debug(e)
 			send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
 			return
+
+		# check if we already got a post to this group with the same message_id
+		existing_post = Post.objects.filter(msg_id=msg_id, group=group)
+		if existing_post.exists():
+			return 
 		
 		email_message = message_from_string(str(message))
 		msg_text = get_body(email_message)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -259,6 +259,8 @@ def handle_post(message, address=None, host=None):
 			send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
 			return
 
+		# try to detect and prevent duplicate posts 
+
 		# check if we already got a post to this group with the same message_id
 		existing_post_matching_id = Post.objects.filter(msg_id=msg_id, group=group)
 		if existing_post_matching_id.exists():
@@ -271,6 +273,12 @@ def handle_post(message, address=None, host=None):
 		if existing_post_recent.exists():
 			logging.debug("Post with same sender and subject sent to this group < 10 min ago")
 			return
+
+		original_sender = message.get('X-Original-Sender', None)
+		if original_sender is not None and original_sender.lower() == group_name:
+			logging.debug('This message originally came from this list; not reposting')
+			return
+
 
 		
 		email_message = message_from_string(str(message))

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -274,12 +274,9 @@ def handle_post(message, address=None, host=None):
 			logging.debug("Post with same sender and subject sent to this group < 10 min ago")
 			return
 
-		original_sender = message.get('X-Original-Sender', None)
-		if original_sender is not None and original_sender.lower() == group_name:
+		if 'X-Original-Sender' in message and message['X-Original-Sender'] == group_name:
 			logging.debug('This message originally came from this list; not reposting')
 			return
-
-
 		
 		email_message = message_from_string(str(message))
 		msg_text = get_body(email_message)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -242,6 +242,8 @@ def handle_post(message, address=None, host=None):
 		name, sender_addr = parseaddr(message['From'].lower())
 		list_name, list_addr = parseaddr(message['List-Id'])
 		to_name, to_addr = parseaddr(message['To'].lower())
+		msg_id = Message['Message-ID']
+		logging.debug("msg id is " + msg_id)
 
 		reserved = filter(lambda x: address.endswith(x), RESERVED)
 		if(reserved):
@@ -315,9 +317,9 @@ def handle_post(message, address=None, host=None):
 			original_list_email = original_list.email
 
 		if message_is_reply:
-			res = insert_reply(group_name, "Re: " + orig_message, msg_text['html'], user, sender_addr, forwarding_list=original_list)
+			res = insert_reply(group_name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
 		else:
-			res = insert_post(group_name, orig_message, msg_text['html'], user, sender_addr, forwarding_list=original_list)
+			res = insert_post(group_name, orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
 			
 		if not res['status']:
 			send_error_email(group_name, res['code'], sender_addr, ADMIN_EMAILS)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -274,13 +274,11 @@ def handle_post(message, address=None, host=None):
 			logging.debug("Post with same sender and subject sent to this group < 10 min ago")
 			return
 
+		# this is the case where we forward a message to a google group, and it forwards back to us
 		if 'X-Original-Sender' in message and message['X-Original-Sender'].split('@')[0] == group_name:
 			logging.debug('This message originally came from this list; not reposting')
 			return
 
-		# logging.debug("passed all those checks... message is ")
-		# logging.debug(message)
-		
 		email_message = message_from_string(str(message))
 		msg_text = get_body(email_message)
 	

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -274,12 +274,12 @@ def handle_post(message, address=None, host=None):
 			logging.debug("Post with same sender and subject sent to this group < 10 min ago")
 			return
 
-		if 'X-Original-Sender' in message and message['X-Original-Sender'] == group_name:
+		if 'X-Original-Sender' in message and message['X-Original-Sender'].split('@')[0] == group_name:
 			logging.debug('This message originally came from this list; not reposting')
 			return
 
-		logging.debug("passed all those checks... message is ")
-		logging.debug(message)
+		# logging.debug("passed all those checks... message is ")
+		# logging.debug(message)
 		
 		email_message = message_from_string(str(message))
 		msg_text = get_body(email_message)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -242,7 +242,7 @@ def handle_post(message, address=None, host=None):
 		name, sender_addr = parseaddr(message['From'].lower())
 		list_name, list_addr = parseaddr(message['List-Id'])
 		to_name, to_addr = parseaddr(message['To'].lower())
-		msg_id = Message['Message-ID']
+		msg_id = message['Message-ID']
 		logging.debug("msg id is " + msg_id)
 
 		reserved = filter(lambda x: address.endswith(x), RESERVED)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -309,11 +309,11 @@ def handle_post(message, address=None, host=None):
 		user_lookup = UserProfile.objects.filter(email=sender_addr)
 
 		# try using List-Id field from email
-		original_list_lookup = ForwardingList.objects.filter(email=list_addr, group=group)
+		original_list_lookup = ForwardingList.objects.filter(email=list_addr, group=group, can_post=True)
 
 		# if no valid List-Id, try email's To field
 		if not original_list_lookup.exists():
-			original_list_lookup = ForwardingList.objects.filter(email=to_addr, group=group)
+			original_list_lookup = ForwardingList.objects.filter(email=to_addr, group=group, can_post=True)
 
 		# neither user nor fwding list exist so post is invalid - reject email
 		if not user_lookup.exists() and not original_list_lookup.exists():

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -277,6 +277,9 @@ def handle_post(message, address=None, host=None):
 		if 'X-Original-Sender' in message and message['X-Original-Sender'] == group_name:
 			logging.debug('This message originally came from this list; not reposting')
 			return
+
+		logging.debug("passed all those checks... message is ")
+		logging.debug(message)
 		
 		email_message = message_from_string(str(message))
 		msg_text = get_body(email_message)


### PR DESCRIPTION
* list URL (if it exists) is shown in table
* if a message comes in with a message-id, we use that instead of creating our own. (the only time we make our own now is if someone posts from the murmur web interface.)
* when we receive a message, don't post it if any of the following are true:
1) it shares message-id with existing post to same group; 
2) in the last ten min, we received a post to same group from same sender with same subject line; 
3) we get a message where the "original sender" field (it seems that google groups adds this a murmur group posts to it) is our own group address. 
* fixed bug with looking up the associated mailing lists; wasn't checking if the list actually had permission to post before.
