### PR TITLE
message status; blacklist/whitelist; separating out mail server logic based on website

### DIFF
--- a/browser/templates/squadbox/home.html
+++ b/browser/templates/squadbox/home.html
@@ -50,7 +50,7 @@
   	
 			<span id="logo">SQUADBOX</span>
 		</h2>
-		<h2 property="name">Fight back against harrassment.</h2>
+		<h2 property="name">Fight back against harassment.</h2>
 	</hgroup>
 
 </header>

--- a/engine/constants.py
+++ b/engine/constants.py
@@ -31,4 +31,8 @@ def extract_hash_tags(s):
 		if len(first_three) == 3: break
 	return first_three 
 
-	
+ALLOWED_MESSAGE_STATUSES = {
+	'R' : 'rejected',
+	'P' : 'pending',
+	'A' : 'approved'
+}

--- a/engine/main.py
+++ b/engine/main.py
@@ -10,9 +10,9 @@ from bleach import clean
 from cgi import escape
 import re
 
-from http_handler.settings import BASE_URL
+from http_handler.settings import BASE_URL, WEBSITE
 import json
-from engine.constants import extract_hash_tags
+from engine.constants import extract_hash_tags, ALLOWED_MESSAGE_STATUSES
 
 
 def list_groups(user=None):
@@ -801,7 +801,7 @@ def _create_tag(group, thread, name):
 		t.save()
 	tagthread,_ = TagThread.objects.get_or_create(thread=thread, tag=t)
 
-def _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=None):
+def _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=None, post_status=None):
 
 	try:
 		message_text = message_text.decode("utf-8")
@@ -816,41 +816,51 @@ def _create_post(group, subject, message_text, user, sender_addr, msg_id, forwar
 	thread.subject = stripped_subj
 	thread.group = group
 	thread.save()
+
+	if post_status == None:
+		post_status = 'A'
 	
 	p = Post(msg_id=msg_id, author=user, poster_email = sender_addr, forwarding_list = forwarding_list, 
-			subject=stripped_subj, post=message_text, group=group, thread=thread)
+			subject=stripped_subj, post=message_text, group=group, thread=thread, status=post_status)
 	p.save()
 	
-	
-	for match in re.findall(r"[^[]*\[([^]]*)\]", subject):
-		if match.lower() != group.name:
-			_create_tag(group, thread, match)
-	
-	tags = list(extract_hash_tags(message_text))
-	for tag in tags:
-		if tag.lower() != group.name:
-			_create_tag(group, thread, tag)
-	
-	tag_objs = Tag.objects.filter(tagthread__thread=thread)
-	tags = list(tag_objs.values('name', 'color'))
-	
-	group_members = MemberGroup.objects.filter(group=group)
-	
-	recipients = []
-	for m in group_members:
-		if not m.no_emails and m.member.email != sender_addr:
-			mute_tag = MuteTag.objects.filter(tag__in=tag_objs, group=group, user=m.member).exists()
-			if not mute_tag:
-				recipients.append(m.member.email)
-		else:
-			follow_tag = FollowTag.objects.filter(tag__in=tag_objs, group=group, user=m.member).exists()
-			if follow_tag:
-				recipients.append(m.member.email)
-	
-	if user:
-		recipients.append(user.email)
-		f = Following(user=user, thread=thread)
-		f.save()
+	if WEBSITE == 'murmur':
+		for match in re.findall(r"[^[]*\[([^]]*)\]", subject):
+			if match.lower() != group.name:
+				_create_tag(group, thread, match)
+		
+		tags = list(extract_hash_tags(message_text))
+		for tag in tags:
+			if tag.lower() != group.name:
+				_create_tag(group, thread, tag)
+		
+		tag_objs = Tag.objects.filter(tagthread__thread=thread)
+		tags = list(tag_objs.values('name', 'color'))
+		
+		group_members = MemberGroup.objects.filter(group=group)
+		
+		recipients = []
+		for m in group_members:
+			if not m.no_emails and m.member.email != sender_addr:
+				mute_tag = MuteTag.objects.filter(tag__in=tag_objs, group=group, user=m.member).exists()
+				if not mute_tag:
+					recipients.append(m.member.email)
+			else:
+				follow_tag = FollowTag.objects.filter(tag__in=tag_objs, group=group, user=m.member).exists()
+				if follow_tag:
+					recipients.append(m.member.email)
+		
+		if user:
+			recipients.append(user.email)
+			f = Following(user=user, thread=thread)
+			f.save()
+
+	elif WEBSITE == 'squadbox':
+		# later on there will be various user options for this. for now just choose 
+		# to send to all moderators.
+		recipients = [m.member.email for m in MemberGroup.objects.filter(group=group, moderator=True)]
+		tags = None
+		tag_objs = None 
 	
 	return p, thread, recipients, tags, tag_objs
 
@@ -911,27 +921,29 @@ def insert_post_web(group_name, subject, message_text, user):
 	return res
 
 
-def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, forwarding_list=None):
+def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, forwarding_list=None, post_status=None):
 	res = {'status':False}
 	thread = None
 	try:
 		group = Group.objects.get(name=group_name)
 
-		# this post did not come from a forwarding list. thus we should only
-		# post it if the user is a member of the group. 
-		if user and not forwarding_list:
-			user_member = MemberGroup.objects.filter(group=group, member=user)
-			if not user_member.exists():
-				res['code'] = msg_code['NOT_MEMBER']
-				return res
+		if WEBSITE == 'murmur':
+			# this post did not come from a forwarding list. thus we should only
+			# post it if the user is a member of the group. 
+			if user and not forwarding_list:
+				user_member = MemberGroup.objects.filter(group=group, member=user)
+				if not user_member.exists():
+					res['code'] = msg_code['NOT_MEMBER']
+					return res
 
 		# if we make it to here, then post is valid under one of following conditions:
 		# 1) it's a normal post by a group member to the group.
 		# 2) it's a post by a Murmur user, but it's being posted to this group via a list that fwds to this group. 
 		# 3) it's a post by someone who doesn't use Murmur, via a list that fwds to this group. 
+		# 4) it's a Squadbox post, so we don't care if the sender has an account / is authorized. 
 		# _create_post will check which of user and forwarding list are None and post appropriately. 
 
-		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=forwarding_list)
+		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, forwarding_list=forwarding_list, post_status=post_status)
 		res['status'] = True
 		res['post_id'] = p.id
 		res['msg_id'] = p.msg_id
@@ -952,7 +964,6 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, fo
 
 	logging.debug(res)
 	return res
-	
 
 
 def insert_reply(group_name, subject, message_text, user, sender_addr, msg_id, forwarding_list=None, thread_id=None):

--- a/schema/models.py
+++ b/schema/models.py
@@ -13,7 +13,7 @@ class Post(models.Model):
 	post = models.TextField()
 	group = models.ForeignKey('Group')
 	thread = models.ForeignKey('Thread')
-	reply_to = models.ForeignKey('self', blank=False, null = True, related_name="replies")
+	reply_to = models.ForeignKey('self', blank=False, null=True, related_name="replies")
 	timestamp = models.DateTimeField(auto_now=True)
 	forwarding_list = models.ForeignKey('ForwardingList', null=True)
 	# a post's author is the Murmur user (if any) who wrote the post.
@@ -23,6 +23,9 @@ class Post(models.Model):
 	# a member of this group on Murmur, and it was likely received via a list that
 	# fwds to this Murmur group
 	poster_email = models.EmailField(max_length=255, null=True)
+
+	STATUS_CHOICES = (('R', 'rejected'), ('P', 'pending'), ('A', 'approved'))
+	status = models.CharField(max_length=1, choices=STATUS_CHOICES, default='A')
 
 	def __unicode__(self):
 		if self.author:
@@ -143,7 +146,18 @@ class Group(models.Model):
 	class Meta:
 		db_table = "murmur_groups"
 
+class WhiteOrBlacklist(models.Model):
 
+	id = models.AutoField(primary_key=True)
+	group = models.ForeignKey('Group')
+	email = models.EmailField(max_length=255)
+
+	# only one of the following can be true
+	whitelist = models.BooleanField(default=False)
+	blacklist = models.BooleanField(default=False)
+
+	# timestamp (for temporary bans)
+	timestamp = models.DateTimeField(auto_now=True)
 
 class MyUserManager(BaseUserManager):
 	def create_user(self, email, password=None):

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -26,33 +26,49 @@ Murmur Mail Interface Handler
 @route("(address)@(host)", address="all", host=HOST)
 @stateless
 def all(message, address=None, host=None):
-	res = list_groups()
-	subject = "Listing Groups -- Success"
-	body = "Listing all the groups \n\n"
-	if(res['status']):
-		for g in res['groups']:
-			body= body + "Name: " + g['name'] + "\t\tActive:" + str(g['active']) + "\n"  
-	else:
-		subject = "Listing Groups -- Error"
-		body = "Error Message: %s" %(res['code'])
-	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
-	relay.deliver(mail)
+	# no public groups to list on squadbox. 
+	if WEBSITE == 'squadbox':
+		logging.debug("Ignored message to all@%s, no public groups to list" % HOST)
+		return
+
+	elif WEBSITE == 'murmur':
+		res = list_groups()
+		subject = "Listing Groups -- Success"
+		body = "Listing all the groups \n\n"
+		if(res['status']):
+			for g in res['groups']:
+				body= body + "Name: " + g['name'] + "\t\tActive:" + str(g['active']) + "\n"  
+		else:
+			subject = "Listing Groups -- Error"
+			body = "Error Message: %s" %(res['code'])
+		mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+create@(host)", group_name=".+", host=HOST)
 @stateless
 def create(message, group_name=None, host=None):
-	group_name = group_name.lower()
-	name, addr = parseaddr(message['from'].lower())
-	res = create_group(group_name, addr)
-	subject = "Create Group -- Success"
-	body = "Mailing group %s@%s created" %(group_name, host)
-	if(not res['status']):
-		subject = "Create Group -- Error"
-		body = "Error Message: %s" %(res['code'])
-	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
-	relay.deliver(mail)
+	# at least for now, for now we don't need this
+	if WEBSITE == 'squadbox':
+		logging.debug("Ignored message to create group via email, not used in Squadbox")
+		return
 
+	elif WEBSITE == 'murmur':
+		group_name = group_name.lower()
+		name, addr = parseaddr(message['from'].lower())
+		res = create_group(group_name, addr)
+		subject = "Create Group -- Success"
+		body = "Mailing group %s@%s created" %(group_name, host)
+		if(not res['status']):
+			subject = "Create Group -- Error"
+			body = "Error Message: %s" %(res['code'])
+		mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
+		relay.deliver(mail)
+
+# don't worry about this part of the code. activating and deactivating don't 
+# actually do anything on murmur, at least as of now. 
+
+'''
 @route("(group_name)\\+activate@(host)", group_name=".+", host=HOST)
 @stateless
 def activate(message, group_name=None, host=None):
@@ -68,9 +84,6 @@ def activate(message, group_name=None, host=None):
 	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body) 
 	relay.deliver(mail)
 
-
-
-
 @route("(group_name)\\+deactivate@(host)", group_name=".+", host=HOST)
 @stateless
 def deactivate(message, group_name=None, host=None):
@@ -85,90 +98,107 @@ def deactivate(message, group_name=None, host=None):
 		body = "Error Message: %s" %(res['code'])
 	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body) 
 	relay.deliver(mail)
+'''
 
 
+# A route to provide a contact email address for a group's administrator(s)
 @route("(group_name)\\+admins@(host)", group_name=".+", host=HOST)
 @stateless
 def admins(message, group_name=None, host=None):
 
-	group_name = group_name.lower()
-	name, sender_addr = parseaddr(message['From'].lower())
-
-	try:
-		group = Group.objects.get(name=group_name)
-	except Exception, e:
-		logging.debug(e)
-		send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
+	# the only admin of a squadbox group is the person who
+	# created the group. having the +admins route would just be 
+	# a way to circumvent moderation / serves no purpose as of now
+	if WEBSITE == 'squadbox':
+		logging.debug("Ignoring message to admin")
 		return
 
-	email_message = message_from_string(str(message))
-	msg_text = get_body(email_message)
+	elif WEBSITE == 'murmur':
+		group_name = group_name.lower()
+		name, sender_addr = parseaddr(message['From'].lower())
 
-	if 'html' not in msg_text or msg_text['html'] == '':
-		msg_text['html'] = markdown(msg_text['plain'])
-	if 'plain' not in msg_text or msg_text['plain'] == '':
-		msg_text['plain'] = html2text(msg_text['html'])
+		try:
+			group = Group.objects.get(name=group_name)
+		except Exception, e:
+			logging.debug(e)
+			send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
+			return
 
-	mail = MurmurMailResponse(From = sender_addr, 
-			To = group_name+"+admins@" + HOST, 
-			Subject = message['Subject'])
+		email_message = message_from_string(str(message))
+		msg_text = get_body(email_message)
 
-	mail.Html = msg_text['html']
-	mail.Body = msg_text['plain']
+		if 'html' not in msg_text or msg_text['html'] == '':
+			msg_text['html'] = markdown(msg_text['plain'])
+		if 'plain' not in msg_text or msg_text['plain'] == '':
+			msg_text['plain'] = html2text(msg_text['html'])
 
-	mail.Body += '\n\nYou are receiving this message because you are an admin of the Murmur group %s.' %(group_name)
-	mail.Html += '<BR><BR>You are receiving this message because you are an admin of the Murmur group %s.' %(group_name)
+		mail = MurmurMailResponse(From = sender_addr, 
+				To = group_name+"+admins@" + HOST, 
+				Subject = message['Subject'])
 
-	try:
-		admins = MemberGroup.objects.filter(group=group, admin=True)
-	except Exception, e:
-		logging.debug(e)
-		send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
-		return
+		mail.Html = msg_text['html']
+		mail.Body = msg_text['plain']
 
-	logging.debug(admins)
-	for a in admins:
-		email = a.member.email
-		relay.deliver(mail, To = email)
+		mail.Body += '\n\nYou are receiving this message because you are an admin of the Murmur group %s.' %(group_name)
+		mail.Html += '<BR><BR>You are receiving this message because you are an admin of the Murmur group %s.' %(group_name)
+
+		try:
+			admins = MemberGroup.objects.filter(group=group, admin=True)
+		except Exception, e:
+			logging.debug(e)
+			send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
+			return
+
+		logging.debug(admins)
+		for a in admins:
+			email = a.member.email
+			relay.deliver(mail, To = email)
 
 
 @route("(group_name)\\+subscribe@(host)", group_name=".+", host=HOST)
 @stateless
 def subscribe(message, group_name=None, host=None):
 
-	group = None
-	group_name = group_name.lower()
-	name, addr = parseaddr(message['from'].lower())
-
-	try:
-		user = UserProfile.objects.get(email=addr)
-		group = Group.objects.get(name=group_name)
-
-	except UserProfile.DoesNotExist:
-		error_msg = 'Your email is not in the %s system. Ask the admin of the group to add you.' % WEBSITE
-		send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+	# people will never be able to subscribe to a squadbox
+	# group themselves; they must be added by the admin. 
+	if WEBSITE == 'squadbox':
+		logging.debug("No subscribing via email in Squadbox")
 		return
 
-	except Group.DoesNotExist:
-		error_msg = 'The group' + group_name + 'does not exist.'
-		send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
-		return
+	elif WEBSITE == 'murmur':
+		group = None
+		group_name = group_name.lower()
+		name, addr = parseaddr(message['from'].lower())
 
-	if not group.public:
-		error_msg = 'The group ' + group_name + ' is private. Ask the admin of the group to add you.'
-		send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
-		return
+		try:
+			user = UserProfile.objects.get(email=addr)
+			group = Group.objects.get(name=group_name)
 
-	res = subscribe_group(group_name, user)
-	subject = "Subscribe -- Success"
-	body = "You are now subscribed to: %s@%s" %(group_name, host)
+		except UserProfile.DoesNotExist:
+			error_msg = 'Your email is not in the %s system. Ask the admin of the group to add you.' % WEBSITE
+			send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+			return
 
-	if(not res['status']):
-		subject = "Subscribe -- Error"
-		body = "Error Message: %s" %(res['code'])
+		except Group.DoesNotExist:
+			error_msg = 'The group' + group_name + 'does not exist.'
+			send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+			return
 
-	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body) 
-	relay.deliver(mail)
+		if not group.public:
+			error_msg = 'The group ' + group_name + ' is private. Ask the admin of the group to add you.'
+			send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+			return
+
+		res = subscribe_group(group_name, user)
+		subject = "Subscribe -- Success"
+		body = "You are now subscribed to: %s@%s" %(group_name, host)
+
+		if(not res['status']):
+			subject = "Subscribe -- Error"
+			body = "Error Message: %s" %(res['code'])
+
+		mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body) 
+		relay.deliver(mail)
 
 
 
@@ -177,30 +207,35 @@ def subscribe(message, group_name=None, host=None):
 @stateless
 def unsubscribe(message, group_name=None, host=None):
 
-	group = None
-	group_name = group_name.lower()
-	name, addr = parseaddr(message['from'].lower())
-
-	try:
-		user = UserProfile.objects.get(email=addr)
-
-	except UserProfile.DoesNotExist:
-		error_msg = 'Your email is not in the %s system. Ask the admin of the group to add you.' % WEBSITE
-		send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+	if WEBSITE == 'squadbox':
+		logging.debug("No unsubscribing via email in Squadbox")
 		return
 
-	res = unsubscribe_group(group_name, user)
-	subject = "Unsubscribe -- Success"
-	body = "You are now unsubscribed from: %s@%s." %(group_name, host)
-	body += " To resubscribe, reply to this email."
+	elif WEBSITE == 'murmur':
+		group = None
+		group_name = group_name.lower()
+		name, addr = parseaddr(message['from'].lower())
 
-	if(not res['status']):
-		subject = "Unsubscribe -- Error"
-		body = "Error Message: %s" %(res['code'])
+		try:
+			user = UserProfile.objects.get(email=addr)
 
-	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
-	mail['Reply-To'] = '%s+subscribe@%s' %(group_name, host)
-	relay.deliver(mail)
+		except UserProfile.DoesNotExist:
+			error_msg = 'Your email is not in the %s system. Ask the admin of the group to add you.' % WEBSITE
+			send_error_email(group_name, error_msg, addr, ADMIN_EMAILS)
+			return
+
+		res = unsubscribe_group(group_name, user)
+		subject = "Unsubscribe -- Success"
+		body = "You are now unsubscribed from: %s@%s." %(group_name, host)
+		body += " To resubscribe, reply to this email."
+
+		if(not res['status']):
+			subject = "Unsubscribe -- Error"
+			body = "Error Message: %s" %(res['code'])
+
+		mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
+		mail['Reply-To'] = '%s+subscribe@%s' %(group_name, host)
+		relay.deliver(mail)
 
 
 
@@ -208,26 +243,34 @@ def unsubscribe(message, group_name=None, host=None):
 @route("(group_name)\\+info@(host)", group_name=".+", host=HOST)
 @stateless
 def info(message, group_name=None, host=None):
-	group_name = group_name.lower()
-	res = group_info(group_name)
-	subject = "Group Info -- Success"
-	body = "Group info for %s:\n" %(group_name)
-	if(res['status']):
-		body = "Group Name: %s@%s, Active: %s\n\n" %(res['group_name'], host, res['active'])
-		for member in res['members']:			
-			body += "%s : %s\n" %('Email: ', member['email'])
-			body += "%s : %s\n" %('Active: ', member['active'])
-			body += "%s : %s\n" %('Member: ', member['member'])
-			body += "%s : %s\n" %('Guest: ', member['guest'])
-			body += "%s : %s\n" %('Moderator: ', member['moderator'])
-			body += "%s : %s\n" %('Admin: ', member['admin'])
-		body += "\n..........................\n"       
-	else:
-		subject = "Group Info -- Error"
-		body = "Error Message: %s" %(res['code'])
-		
-	mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
-	relay.deliver(mail)
+
+	# for now I'm not sure what we would have here, 
+	# but we can change this later on.
+	if WEBSITE == 'squadbox':
+		logging.debug("No group info sent via email in Squadbox")
+		return
+
+	elif WEBSITE == 'murmur':
+		group_name = group_name.lower()
+		res = group_info(group_name)
+		subject = "Group Info -- Success"
+		body = "Group info for %s:\n" %(group_name)
+		if(res['status']):
+			body = "Group Name: %s@%s, Active: %s\n\n" %(res['group_name'], host, res['active'])
+			for member in res['members']:			
+				body += "%s : %s\n" %('Email: ', member['email'])
+				body += "%s : %s\n" %('Active: ', member['active'])
+				body += "%s : %s\n" %('Member: ', member['member'])
+				body += "%s : %s\n" %('Guest: ', member['guest'])
+				body += "%s : %s\n" %('Moderator: ', member['moderator'])
+				body += "%s : %s\n" %('Admin: ', member['admin'])
+			body += "\n..........................\n"       
+		else:
+			subject = "Group Info -- Error"
+			body = "Error Message: %s" %(res['code'])
+			
+		mail = MailResponse(From = NO_REPLY, To = message['From'], Subject = subject, Body = body)
+		relay.deliver(mail)
 
 
 @route("(address)@(host)", address=".+", host=HOST)
@@ -236,379 +279,437 @@ def handle_post(message, address=None, host=None):
 	if '+' in address and '__' in address:
 		return
 
-	try:
-		#does this fix the MySQL has gone away error?
-		django.db.close_connection()
-		
-		address = address.lower()
-		name, sender_addr = parseaddr(message['From'].lower())
-		list_name, list_addr = parseaddr(message['List-Id'])
-		to_name, to_addr = parseaddr(message['To'].lower())
-		msg_id = message['Message-ID']
-		logging.debug("msg id is " + msg_id)
+	if WEBSITE == 'squadbox':
+		return
 
-		reserved = filter(lambda x: address.endswith(x), RESERVED)
-		if(reserved):
-			return
-		
-		group_name = address
+	elif WEBSITE == 'murmur':
+
 		try:
-			group = Group.objects.get(name=group_name)
-		except Exception, e:
-			logging.debug(e)
-			send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
-			return
-
-		# try to detect and prevent duplicate posts 
-
-		# check if we already got a post to this group with the same message_id
-		existing_post_matching_id = Post.objects.filter(msg_id=msg_id, group=group)
-		if existing_post_matching_id.exists():
-			logging.debug("Already received post with same msg-id to this group")
-			return
-
-		ten_minutes_ago = datetime.now(pytz.utc) + timedelta(minutes=-10)
-		existing_post_recent = Post.objects.filter(poster_email=sender_addr, group=group, 
-										subject=message['Subject'], timestamp__gte = ten_minutes_ago)
-		if existing_post_recent.exists():
-			logging.debug("Post with same sender and subject sent to this group < 10 min ago")
-			return
-
-		# this is the case where we forward a message to a google group, and it forwards back to us
-		if 'X-Original-Sender' in message and message['X-Original-Sender'].split('@')[0] == group_name:
-			logging.debug('This message originally came from this list; not reposting')
-			return
-
-		email_message = message_from_string(str(message))
-		msg_text = get_body(email_message)
-	
-		attachments = get_attachments(email_message)
-		res = check_attachments(attachments, group.allow_attachments)
-		if not res['status']:
-			send_error_email(group_name, res['error'], sender_addr, ADMIN_EMAILS)
-			return
-
-		message_is_reply = (message['Subject'][0:4].lower() == "re: ")
-		
-		if not message_is_reply:
-			orig_message = message['Subject'].strip()
-		else:
-			orig_message = re.sub("\[.*?\]", "", message['Subject'][4:]).strip()
-			if 'html' in msg_text:
-				msg_text['html'] = remove_html_ps(msg_text['html'])
-			if 'plain' in msg_text:
-				msg_text['plain'] = remove_plain_ps(msg_text['plain'])
-				
-		if 'html' not in msg_text or msg_text['html'] == '':
-			msg_text['html'] = markdown(msg_text['plain'])
-		if 'plain' not in msg_text or msg_text['plain'] == '':
-			msg_text['plain'] = html2text(msg_text['html'])
-
-		if msg_text['plain'].startswith('unsubscribe\n') or msg_text['plain'] == 'unsubscribe':
-			unsubscribe(message, group_name = group_name, host = HOST)
-			return
-		elif msg_text['plain'].startswith('subscribe\n') or msg_text['plain'] == 'subscribe':
-			subscribe(message, group_name = group_name, host = HOST)
-			return
-		
-		# try looking up sender in Murmur users
-		user_lookup = UserProfile.objects.filter(email=sender_addr)
-
-		# try using List-Id field from email
-		original_list_lookup = ForwardingList.objects.filter(email=list_addr, group=group, can_post=True)
-
-		# if no valid List-Id, try email's To field
-		if not original_list_lookup.exists():
-			original_list_lookup = ForwardingList.objects.filter(email=to_addr, group=group, can_post=True)
-
-		# neither user nor fwding list exist so post is invalid - reject email
-		if not user_lookup.exists() and not original_list_lookup.exists():
-			error_msg = 'Your email is not in the Murmur system. Ask the admin of the group to add you.'
-			send_error_email(group_name, error_msg, sender_addr, ADMIN_EMAILS)
-			return
-
-		# get user and/or forwarding list objects to pass to insert_reply or insert_post 
-		user = None
-		if user_lookup.exists():
-			user = user_lookup[0]
-
-		original_list = None
-		original_list_email = None
-		if original_list_lookup.exists():
-			original_list = original_list_lookup[0]
-			original_list_email = original_list.email
-
-		if message_is_reply:
-			res = insert_reply(group_name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
-		else:
-			res = insert_post(group_name, orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
+			#does this fix the MySQL has gone away error?
+			django.db.close_connection()
 			
-		if not res['status']:
-			send_error_email(group_name, res['code'], sender_addr, ADMIN_EMAILS)
-			return
+			address = address.lower()
+			name, sender_addr = parseaddr(message['From'].lower())
+			list_name, list_addr = parseaddr(message['List-Id'])
+			to_name, to_addr = parseaddr(message['To'].lower())
+			msg_id = message['Message-ID']
+			logging.debug("msg id is " + msg_id)
 
-		subject = get_subject(message, res, group_name)
+			reserved = filter(lambda x: address.endswith(x), RESERVED)
+			if(reserved):
+				return
 			
-		mail = setup_post(message['From'],
-							subject,	
-							group_name)
-			
-		for attachment in attachments.get("attachments"):
-			mail.attach(filename=attachment['filename'],
-						content_type=attachment['mime'],
-						data=attachment['content'],
-						disposition=attachment['disposition'],
-						id=attachment['id'])
-			
-		if 'references' in message:
-			mail['References'] = message['references']
-		elif 'message-id' in message:
-			mail['References'] = message['message-id']	
-	
-		if 'in-reply-to' not in message:
-			mail["In-Reply-To"] = message['message-id']
-	
-		msg_id = res['msg_id']
-		to_send =  res['recipients']
-		
-		mail['message-id'] = msg_id
-		
-		ccs = email_message.get_all('cc', None)
-		if ccs:
-			mail['Cc'] = ','.join(ccs)
+			group_name = address
+			try:
+				group = Group.objects.get(name=group_name)
+			except Exception, e:
+				logging.debug(e)
+				send_error_email(group_name, e, sender_addr, ADMIN_EMAILS)	
+				return
 
-		logging.debug('TO LIST: ' + str(to_send))
+			# try to detect and prevent duplicate posts 
+
+			# check if we already got a post to this group with the same message_id
+			existing_post_matching_id = Post.objects.filter(msg_id=msg_id, group=group)
+			if existing_post_matching_id.exists():
+				logging.debug("Already received post with same msg-id to this group")
+				return
+
+			ten_minutes_ago = datetime.now(pytz.utc) + timedelta(minutes=-10)
+			existing_post_recent = Post.objects.filter(poster_email=sender_addr, group=group, 
+											subject=message['Subject'], timestamp__gte = ten_minutes_ago)
+			if existing_post_recent.exists():
+				logging.debug("Post with same sender and subject sent to this group < 10 min ago")
+				return
+
+			# this is the case where we forward a message to a google group, and it forwards back to us
+			if 'X-Original-Sender' in message and message['X-Original-Sender'].split('@')[0] == group_name:
+				logging.debug('This message originally came from this list; not reposting')
+				return
+
+			email_message = message_from_string(str(message))
+			msg_text = get_body(email_message)
 		
-		g = Group.objects.get(name=group_name)
-		t = Thread.objects.get(id=res['thread_id'])
-		
-		direct_recips = get_direct_recips(email_message)
-		
-		try:
-			if len(to_send) > 0:
-				
-				recips = UserProfile.objects.filter(email__in=to_send)
-				membergroups = MemberGroup.objects.filter(group=g, member__in=recips)
-				followings = Following.objects.filter(thread=t, user__in=recips)
-				mutings = Mute.objects.filter(thread=t, user__in=recips)
-				
-				tag_followings = FollowTag.objects.filter(group=g, tag__in=res['tag_objs'], user__in=recips)
-				tag_mutings = MuteTag.objects.filter(group=g, tag__in=res['tag_objs'], user__in=recips)
-				
-				for recip in recips:
+			attachments = get_attachments(email_message)
+			res = check_attachments(attachments, group.allow_attachments)
+			if not res['status']:
+				send_error_email(group_name, res['error'], sender_addr, ADMIN_EMAILS)
+				return
+
+			message_is_reply = (message['Subject'][0:4].lower() == "re: ")
+			
+			if not message_is_reply:
+				orig_message = message['Subject'].strip()
+			else:
+				orig_message = re.sub("\[.*?\]", "", message['Subject'][4:]).strip()
+				if 'html' in msg_text:
+					msg_text['html'] = remove_html_ps(msg_text['html'])
+				if 'plain' in msg_text:
+					msg_text['plain'] = remove_plain_ps(msg_text['plain'])
 					
-					# Don't send email to the sender if it came from email
-					# Don't send email to people that already directly got the email via CC/BCC
-					if recip.email == sender_addr or recip.email in direct_recips:
-						continue
+			if 'html' not in msg_text or msg_text['html'] == '':
+				msg_text['html'] = markdown(msg_text['plain'])
+			if 'plain' not in msg_text or msg_text['plain'] == '':
+				msg_text['plain'] = html2text(msg_text['html'])
 
-					membergroup = membergroups.filter(member=recip)[0]
-					following = followings.filter(user=recip).exists()
-					muting = mutings.filter(user=recip).exists()
-					tag_following = tag_followings.filter(user=recip)
-					tag_muting = tag_mutings.filter(user=recip)
+			if msg_text['plain'].startswith('unsubscribe\n') or msg_text['plain'] == 'unsubscribe':
+				unsubscribe(message, group_name = group_name, host = HOST)
+				return
+			elif msg_text['plain'].startswith('subscribe\n') or msg_text['plain'] == 'subscribe':
+				subscribe(message, group_name = group_name, host = HOST)
+				return
+			
+			# try looking up sender in Murmur users
+			user_lookup = UserProfile.objects.filter(email=sender_addr)
+
+			# try using List-Id field from email
+			original_list_lookup = ForwardingList.objects.filter(email=list_addr, group=group, can_post=True)
+
+			# if no valid List-Id, try email's To field
+			if not original_list_lookup.exists():
+				original_list_lookup = ForwardingList.objects.filter(email=to_addr, group=group, can_post=True)
+
+			# neither user nor fwding list exist so post is invalid - reject email
+			if not user_lookup.exists() and not original_list_lookup.exists():
+				error_msg = 'Your email is not in the Murmur system. Ask the admin of the group to add you.'
+				send_error_email(group_name, error_msg, sender_addr, ADMIN_EMAILS)
+				return
+
+			# get user and/or forwarding list objects to pass to insert_reply or insert_post 
+			user = None
+			if user_lookup.exists():
+				user = user_lookup[0]
+
+			original_list = None
+			original_list_email = None
+			if original_list_lookup.exists():
+				original_list = original_list_lookup[0]
+				original_list_email = original_list.email
+
+			if message_is_reply:
+				res = insert_reply(group_name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
+			else:
+				res = insert_post(group_name, orig_message, msg_text['html'], user, sender_addr, msg_id, forwarding_list=original_list)
 				
-					html_ps_blurb = html_ps(g, t, res['post_id'], membergroup, following, muting, tag_following, tag_muting, res['tag_objs'], original_list_email=original_list_email)
-					html_ps_blurb = unicode(html_ps_blurb)
-					mail.Html = get_new_body(msg_text, html_ps_blurb, 'html')
-					
-					plain_ps_blurb = plain_ps(g, t, res['post_id'], membergroup, following, muting, tag_following, tag_muting, res['tag_objs'], original_list_email=original_list_email)
-					mail.Body = get_new_body(msg_text, plain_ps_blurb, 'plain')
+			if not res['status']:
+				send_error_email(group_name, res['code'], sender_addr, ADMIN_EMAILS)
+				return
+
+			subject = get_subject(message, res, group_name)
+				
+			mail = setup_post(message['From'],
+								subject,	
+								group_name)
+				
+			for attachment in attachments.get("attachments"):
+				mail.attach(filename=attachment['filename'],
+							content_type=attachment['mime'],
+							data=attachment['content'],
+							disposition=attachment['disposition'],
+							id=attachment['id'])
+				
+			if 'references' in message:
+				mail['References'] = message['references']
+			elif 'message-id' in message:
+				mail['References'] = message['message-id']	
 		
-					relay.deliver(mail, To = recip.email)
+			if 'in-reply-to' not in message:
+				mail["In-Reply-To"] = message['message-id']
+		
+			msg_id = res['msg_id']
+			to_send =  res['recipients']
+			
+			mail['message-id'] = msg_id
+			
+			ccs = email_message.get_all('cc', None)
+			if ccs:
+				mail['Cc'] = ','.join(ccs)
 
-			fwd_to_lists = ForwardingList.objects.filter(group=g, can_receive=True)
+			logging.debug('TO LIST: ' + str(to_send))
+			
+			g = Group.objects.get(name=group_name)
+			t = Thread.objects.get(id=res['thread_id'])
+			
+			direct_recips = get_direct_recips(email_message)
+			
+			try:
+				if len(to_send) > 0:
+					
+					recips = UserProfile.objects.filter(email__in=to_send)
+					membergroups = MemberGroup.objects.filter(group=g, member__in=recips)
+					followings = Following.objects.filter(thread=t, user__in=recips)
+					mutings = Mute.objects.filter(thread=t, user__in=recips)
+					
+					tag_followings = FollowTag.objects.filter(group=g, tag__in=res['tag_objs'], user__in=recips)
+					tag_mutings = MuteTag.objects.filter(group=g, tag__in=res['tag_objs'], user__in=recips)
+					
+					for recip in recips:
+						
+						# Don't send email to the sender if it came from email
+						# Don't send email to people that already directly got the email via CC/BCC
+						if recip.email == sender_addr or recip.email in direct_recips:
+							continue
 
-			for l in fwd_to_lists:
-				# non murmur list, send as usual 
-				if HOST not in l.email:
+						membergroup = membergroups.filter(member=recip)[0]
+						following = followings.filter(user=recip).exists()
+						muting = mutings.filter(user=recip).exists()
+						tag_following = tag_followings.filter(user=recip)
+						tag_muting = tag_mutings.filter(user=recip)
+					
+						html_ps_blurb = html_ps(g, t, res['post_id'], membergroup, following, muting, tag_following, tag_muting, res['tag_objs'], original_list_email=original_list_email)
+						html_ps_blurb = unicode(html_ps_blurb)
+						mail.Html = get_new_body(msg_text, html_ps_blurb, 'html')
+						
+						plain_ps_blurb = plain_ps(g, t, res['post_id'], membergroup, following, muting, tag_following, tag_muting, res['tag_objs'], original_list_email=original_list_email)
+						mail.Body = get_new_body(msg_text, plain_ps_blurb, 'plain')
+			
+						relay.deliver(mail, To = recip.email)
 
-					footer_html = html_forwarded_blurb(g.name, l.email, original_list_email=original_list_email)
-					footer_plain = plain_forwarded_blurb(g.name, l.email, original_list_email=original_list_email)
+				fwd_to_lists = ForwardingList.objects.filter(group=g, can_receive=True)
 
-					mail.Html = get_new_body(msg_text, footer_html, 'html')
-					mail.Body = get_new_body(msg_text, footer_plain, 'plain')
+				for l in fwd_to_lists:
+					# non murmur list, send as usual 
+					if HOST not in l.email:
 
-					relay.deliver(mail, To = l.email)
-				# it's another murmur list. can't send mail to ourself ("loops back to 
-				#myself" error) so have to directly pass back to handle_post 
-				else:
-					group_name = l.email.split('@')[0]
-					handle_post(message, address=group_name)
+						footer_html = html_forwarded_blurb(g.name, l.email, original_list_email=original_list_email)
+						footer_plain = plain_forwarded_blurb(g.name, l.email, original_list_email=original_list_email)
+
+						mail.Html = get_new_body(msg_text, footer_html, 'html')
+						mail.Body = get_new_body(msg_text, footer_plain, 'plain')
+
+						relay.deliver(mail, To = l.email)
+					# it's another murmur list. can't send mail to ourself ("loops back to 
+					#myself" error) so have to directly pass back to handle_post 
+					else:
+						group_name = l.email.split('@')[0]
+						handle_post(message, address=group_name)
 
 
+			except Exception, e:
+				logging.debug(e)
+				send_error_email(group_name, e, None, ADMIN_EMAILS)
+				
+				# try to deliver mail even without footers
+				mail.Html = msg_text['html']
+				mail.Body = msg_text['plain']
+				relay.deliver(mail, To = to_send)
+					
 		except Exception, e:
 			logging.debug(e)
 			send_error_email(group_name, e, None, ADMIN_EMAILS)
-			
-			# try to deliver mail even without footers
-			mail.Html = msg_text['html']
-			mail.Body = msg_text['plain']
-			relay.deliver(mail, To = to_send)
-				
-	except Exception, e:
-		logging.debug(e)
-		send_error_email(group_name, e, None, ADMIN_EMAILS)
-		return
+			return
 		
 		
 
 @route("(group_name)\\+(thread_id)(suffix)@(host)", group_name=".+", thread_id=".+", suffix=FOLLOW_SUFFIX+"|"+FOLLOW_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_follow(message, group_name=None, thread_id=None, suffix=None, host=None):
-	_, addr = parseaddr(message['From'].lower())
-	res = follow_thread(thread_id, email=addr)
 
-	if res['status']:
-		body = "Success! You are now following the thread \"%s\". You will receive emails for all following replies to this thread." % res['thread_name']
-	else:
-		body = "Sorry there was an error: %s" % res['code']
+	if WEBSITE == 'squadbox':
+		return
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
-	relay.deliver(mail)
+	elif WEBSITE == 'murmur':
+		_, addr = parseaddr(message['From'].lower())
+		res = follow_thread(thread_id, email=addr)
+
+		if res['status']:
+			body = "Success! You are now following the thread \"%s\". You will receive emails for all following replies to this thread." % res['thread_name']
+		else:
+			body = "Sorry there was an error: %s" % res['code']
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(thread_id)(suffix)@(host)", group_name=".+", thread_id=".+", suffix=UNFOLLOW_SUFFIX+"|"+UNFOLLOW_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_unfollow(message, group_name=None, thread_id=None, suffix=None, host=None):
-	_, addr = parseaddr(message['From'].lower())
-	res = unfollow_thread(thread_id, email=addr)
 
-	if res['status']:
-		body = "You unfollowed the thread \"%s\" successfully." % res['thread_name']
-	else:
-		body =  "Error Message: %s" % res['code']
+	if WEBSITE == 'squadbox':
+		return
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
-	relay.deliver(mail)
+	elif WEBSITE == 'murmur':
+
+		_, addr = parseaddr(message['From'].lower())
+		res = unfollow_thread(thread_id, email=addr)
+
+		if res['status']:
+			body = "You unfollowed the thread \"%s\" successfully." % res['thread_name']
+		else:
+			body =  "Error Message: %s" % res['code']
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(thread_id)(suffix)@(host)", group_name=".+", thread_id=".+", suffix=MUTE_SUFFIX+"|"+MUTE_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_mute(message, group_name=None, thread_id=None, suffix=None, host=None):
 
-	_, addr = parseaddr(message['From'].lower())
-	res = mute_thread(thread_id, email=addr)
+	if WEBSITE == 'squadbox':
+		return
 
-	if(res['status']):
-		body = "Success! You have now muted the thread \"%s\"." % res['thread_name']
-	else:
-		body = "Sorry there was an error: %s" % (res['code'])
+	elif WEBSITE == 'murmur':
+		_, addr = parseaddr(message['From'].lower())
+		res = mute_thread(thread_id, email=addr)
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
-	relay.deliver(mail)
+		if(res['status']):
+			body = "Success! You have now muted the thread \"%s\"." % res['thread_name']
+		else:
+			body = "Sorry there was an error: %s" % (res['code'])
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(thread_id)(suffix)@(host)", group_name=".+", thread_id=".+", suffix=UNMUTE_SUFFIX+"|"+UNMUTE_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_unmute(message, group_name=None, thread_id=None, suffix=None, host=None):
 
-	_, addr = parseaddr(message['From'].lower())
-	res = unmute_thread(thread_id, email=addr)
+	if WEBSITE == 'squadbox':
+		return
 
-	if(res['status']):
-		body = "You unmuted the thread \"%s\" successfully. You will receive emails for all following replies to this thread." % res['thread_name']
-	else:
-		body = "Error Message: %s" %(res['code'])
-	
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
-	relay.deliver(mail)
+	elif WEBSITE == 'murmur':
+		_, addr = parseaddr(message['From'].lower())
+		res = unmute_thread(thread_id, email=addr)
+
+		if(res['status']):
+			body = "You unmuted the thread \"%s\" successfully. You will receive emails for all following replies to this thread." % res['thread_name']
+		else:
+			body = "Error Message: %s" %(res['code'])
+		
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['thread_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(tag_name)(suffix)@(host)", group_name=".+", tag_name=".+", suffix=FOLLOW_TAG_SUFFIX+"|"+FOLLOW_TAG_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_follow_tag(message, group_name=None, tag_name=None, suffix=None, host=None):
 
-	_, addr = parseaddr(message['From'].lower())
-	res = follow_tag(tag_name, group_name, email=addr)
+	if WEBSITE == 'squadbox':
+		return
 
-	if(res['status']):
-		body = "Success! You are now following the tag \"%s\". You will receive emails for all following emails with this tag." % res['tag_name']
-	else:
-		body = "Sorry there was an error: %s" % (res['code'])
+	elif WEBSITE == 'murmur':
+		_, addr = parseaddr(message['From'].lower())
+		res = follow_tag(tag_name, group_name, email=addr)
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
-	relay.deliver(mail)
+		if(res['status']):
+			body = "Success! You are now following the tag \"%s\". You will receive emails for all following emails with this tag." % res['tag_name']
+		else:
+			body = "Sorry there was an error: %s" % (res['code'])
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(tag_name)(suffix)@(host)", group_name=".+", tag_name=".+", suffix=UNFOLLOW_TAG_SUFFIX+"|"+UNFOLLOW_TAG_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_unfollow_tag(message, group_name=None, tag_name=None, suffix=None, host=None):
 
-	_, addr = parseaddr(message['From'].lower())
-	res = unfollow_tag(tag_name, group_name, email=addr)
+	if WEBSITE == 'squadbox':
+		return
 
-	if(res['status']):
-		body = "You unfollowed the tag \"%s\" successfully." % res['tag_name']
-	else:
-		body = "Error Message: %s" %(res['code'])
-	
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
-	relay.deliver(mail)
+	elif WEBSITE == 'murmur':
+
+		_, addr = parseaddr(message['From'].lower())
+		res = unfollow_tag(tag_name, group_name, email=addr)
+
+		if(res['status']):
+			body = "You unfollowed the tag \"%s\" successfully." % res['tag_name']
+		else:
+			body = "Error Message: %s" %(res['code'])
+		
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
+		relay.deliver(mail)
 
 
 @route("(group_name)\\+(tag_name)(suffix)@(host)", group_name=".+", tag_name=".+", suffix=MUTE_TAG_SUFFIX+"|"+MUTE_TAG_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_mute_tag(message, group_name=None, tag_name=None, suffix=None, host=None):
-	_, addr = parseaddr(message['From'].lower())
-	res = mute_tag(tag_name, group_name, email=addr)
-	if(res['status']):
-		body = "Success! You have now muted the tag \"%s\"." % res['tag_name']
-	else:
-		body = "Sorry there was an error: %s" % (res['code'])
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
-	relay.deliver(mail)
+	if WEBSITE == 'squadbox':
+		return
+
+	elif WEBSITE == 'murmur':
+
+		_, addr = parseaddr(message['From'].lower())
+		res = mute_tag(tag_name, group_name, email=addr)
+		if(res['status']):
+			body = "Success! You have now muted the tag \"%s\"." % res['tag_name']
+		else:
+			body = "Sorry there was an error: %s" % (res['code'])
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
+		relay.deliver(mail)
 
 @route("(group_name)\\+(tag_name)(suffix)@(host)", group_name=".+", tag_name=".+", suffix=UNMUTE_TAG_SUFFIX+"|"+UNMUTE_TAG_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_unmute_tag(message, group_name=None, tag_name=None, suffix=None, host=None):
-	_, addr = parseaddr(message['From'].lower())
-	res = unmute_tag(tag_name, group_name, email=addr)
-	if(res['status']):
-		body = "You unmuted the tag \"%s\" successfully. You will receive emails for all emails to this tag." % res['tag_name']
-	else:
-		body = "Error Message: %s" %(res['code'])
-	
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
-	relay.deliver(mail)
+
+	if WEBSITE == 'squadbox':
+		return
+
+	elif WEBSITE == 'murmur':
+
+		_, addr = parseaddr(message['From'].lower())
+		res = unmute_tag(tag_name, group_name, email=addr)
+		if(res['status']):
+			body = "You unmuted the tag \"%s\" successfully. You will receive emails for all emails to this tag." % res['tag_name']
+		else:
+			body = "Error Message: %s" %(res['code'])
+		
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = res['tag_name'], Body = body)
+		relay.deliver(mail)
 
 @route("(group_name)\\+(post_id)(suffix)@(host)", group_name=".+", post_id=".+", suffix=UPVOTE_SUFFIX+"|"+UPVOTE_SUFFIX.upper(), host=HOST)
 @stateless
 def handle_upvote(message, group_name=None, post_id=None, suffix=None, host=None):
-	name, addr = parseaddr(message['from'].lower())
-	res = upvote(post_id, email=addr, user=None)
-	if(res['status']):
-		subject = 'Success'
-		body = "Upvoted the post: %s" %(post_id)
 
-	else:
-		subject = 'Error'
-		body = "Invalid post: %s" %(post_id)
+	if WEBSITE == 'squadbox':
+		return
 
-	mail = MailResponse(From = NO_REPLY, To = addr, Subject = subject, Body = body)
-	relay.deliver(mail)
+	elif WEBSITE == 'murmur':
+
+		name, addr = parseaddr(message['from'].lower())
+		res = upvote(post_id, email=addr, user=None)
+		if(res['status']):
+			subject = 'Success'
+			body = "Upvoted the post: %s" %(post_id)
+
+		else:
+			subject = 'Error'
+			body = "Invalid post: %s" %(post_id)
+
+		mail = MailResponse(From = NO_REPLY, To = addr, Subject = subject, Body = body)
+		relay.deliver(mail)
 
 @route("(address)@(host)", address="help", host=HOST)
 @stateless
 def help(message, address=None, host=None):
-	to_addr = message['From']
-	from_addr = address + '@' + HOST
-	subject = "Help"
-	body = "Welcome to %s. Please find below a general help on managing a group mailing list.\n\n" %(host)
-	body += "To create a new group: <name>+create@%s\n" %(host)
-	body += "To activate/re-activate your group: <name>+activate@%s\n" %(host)
-	body += "To de-activate your group: <name>+deactivate@%s\n" %(host)
-	body += "To subscribe to a group: <name>+subscribe@%s\n" %(host)
-	body += "To unsubscribe from a group: <name>+unsubscribe@%s\n" %(host)
-	body += "To see details of a group: <name>+info@%s\n" %(host)
-	body += "To see a listing of all the groups: all@%s\n" %(host)
-	body += "To get help: help@%s\n" %(host)
-	body += "To post message to a group: <name>@%s\n\n" %(host)
-	body += "Please substitute '<name>' with your group name." 	
-	mail = MailResponse(From = from_addr, To = to_addr, Subject = subject, Body = body)
-	relay.deliver(mail)
-	return
+
+	if WEBSITE == 'squadbox':
+		# we should change this to actually send a useful help email
+		# with the possible via-email commands in squadbox
+		return
+
+	elif WEBSITE == 'murmur':
+		to_addr = message['From']
+		from_addr = address + '@' + HOST
+		subject = "Help"
+		body = "Welcome to %s. Please find below a general help on managing a group mailing list.\n\n" %(host)
+		body += "To create a new group: <name>+create@%s\n" %(host)
+		body += "To activate/re-activate your group: <name>+activate@%s\n" %(host)
+		body += "To de-activate your group: <name>+deactivate@%s\n" %(host)
+		body += "To subscribe to a group: <name>+subscribe@%s\n" %(host)
+		body += "To unsubscribe from a group: <name>+unsubscribe@%s\n" %(host)
+		body += "To see details of a group: <name>+info@%s\n" %(host)
+		body += "To see a listing of all the groups: all@%s\n" %(host)
+		body += "To get help: help@%s\n" %(host)
+		body += "To post message to a group: <name>@%s\n\n" %(host)
+		body += "Please substitute '<name>' with your group name." 	
+		mail = MailResponse(From = from_addr, To = to_addr, Subject = subject, Body = body)
+		relay.deliver(mail)
+		return
 
 
 @route("(address)@(host)", address=".+", host=".+")

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -90,6 +90,30 @@ def setup_post(From, Subject, group_name):
 	
 	return mail
 
+def setup_moderation_post(group_name, msg_text, post_id):
+
+	subject = 'Post to Squadbox group %s requires approval' % group_name 
+	to = '%s Moderators <%s+mods@%s>' % (group_name, group_name, HOST)
+	from_addr = 'Squadbox Notifications <%s+notifications@%s>' % (group_name, HOST)
+
+	mail = MurmurMailResponse(From=from_addr, To=to, Subject=subject)
+	mail.update({
+		"Sender" : from_addr,
+		"Reply-To" : from_addr,
+		"List-Id" : from_addr,
+		"Return-Path": from_addr,
+		"Precedence": 'list'
+		})
+
+	html_ps_blurb = 'replace this with a blurb later on!'
+	html_ps_blurb = unicode(html_ps_blurb)
+	mail.Html = get_new_body(msg_text, html_ps_blurb, 'html')
+	
+	plain_ps_blurb = 'replace this with a blurb later on!'
+	mail.Body = get_new_body(msg_text, plain_ps_blurb, 'plain')
+		
+	return mail
+
 def send_error_email(group_name, error, user_addr, admin_emails):
 	mail = MurmurMailResponse(From = NO_REPLY, Subject = "Error")
 	mail.Body = "You tried to post to: %s. Error Message: %s" % (group_name, error)


### PR DESCRIPTION
the main changes here are 
- posts now have a "status" field that can be "approved", "pending", or "rejected". 
- new table for whitelist/blacklist info. 
- splitting up logic in smtp_handler/main.py to do things differently based on the website. for now, most of this is "do nothing if squadbox, do as before if murmur." besides in handle_post, which now branches to two separate functions and sends received emails to a group's moderators. 

because of the new table and the new field in Post, you will have to do a DB migration (just the auto/default one will work) when merging this into production. 