### PR TITLE
updated form submission code w/ tagging

### DIFF
--- a/formEmails/formSubmission.js
+++ b/formEmails/formSubmission.js
@@ -1,4 +1,4 @@
-MAILING_LIST = ''
+MAILING_LIST = '';
 
 
 /* on form submission event e, send an email to MAILING_LIST */
@@ -21,6 +21,24 @@ function sendEmail(e) {
     subject: 'New publication: ' + formData[1],
     htmlBody: email.HTML,
     body: email.plain
+  });
+
+  // send confirmation email
+  var submitterEmail = formData[0];
+  var pubName = formData[1];
+  var editLink = e.response.getEditResponseUrl();
+
+  var confEmailPlain = 'Your publication "' + pubName + '" has been successfully submitted.\n'; 
+  confEmailPlain += 'To edit your submission, visit the following URL: ' + editLink; 
+
+  var confEmailHTML = 'Your publication "' + pubName + '" has been successfully submitted.<br>';
+  confEmailHTML += 'To edit your submission, visit <a href="' + editLink + '">this link.</a>'; 
+
+  MailApp.sendEmail({
+    to: submitterEmail,
+    subject: 'Publication submitted',
+    htmlBody: confEmailHTML,
+    body: confEmailPlain
   });
 }
 
@@ -87,6 +105,30 @@ function generateOther(authors, year, title, venue, pages, plain) {
   return res + '.';
 }
 
+var cats = {
+  'Artificial Intelligence' : 'AI',
+  'Communications' : 'comm',
+  'Computational Biology' : 'comp_bio',
+  'Architecture' : 'architecture',
+  'Graphics and Vision' : 'graphics_vision',
+  'Networks' : 'networks',
+  'Control and Decision Systems' : 'control_decision_sys',
+  'Human-Computer Interaction' : 'HCI',
+  'Inference' : 'inference',
+  'Machine Learning' : 'ML',
+  'Natural Language and Speech Processing' : 'NLP_speech',
+  'Programming Languages' : 'languages',
+  'Software Engineering and Design' : 'sw_eng_design',
+  'Robotics' : 'robotics',
+  'Signal Processing' : 'signal_processing',
+  'Systems' : 'systems',
+  'Theory' : 'theory',
+  'Operating Systems' : 'OS',
+  'Databases' : 'DB',
+  'Security' : 'security', 
+
+}
+
 /* generate plainText and HTML emails using data from publications form. */ 
 function generateEmails(formData) {
   var submitterEmail = formData[0],
@@ -109,6 +151,7 @@ function generateEmails(formData) {
     volume,
     issue,
     venue,
+    categories,
     other,
     keywords;
 
@@ -119,28 +162,34 @@ function generateEmails(formData) {
     pubCity = formData[13];
     proceedingsPublisher = formData[14];
     pages = formData[15];
-    other = formData[16];
-    keywords = formData[17];
+    categories = formData[16];
+    other = formData[17];
+    keywords = formData[18];
   } else if (type == 'Journal article') {
     journal = formData[10];
     volume = formData[11];
     issue = formData[12];
     pages = formData[13];
-    other = formData[14];
-    keywords = formData[15];
+    categories = formData[14];
+    other = formData[15];
+    keywords = formData[16];
   } else {
     venue = formData[10];
     pages = formData[11];
-    other = formData[12];
-    keywords = formData[13];
+    categories = formdata[12];
+    other = formData[13];
+    keywords = formData[14];
   }
 
   var HTML = '<b>Paper submitted by</b>: ' + submitterEmail + '<br><br>';
   var plain = ['Paper submitted by: ' + submitterEmail];
   if (group.length > 0) {
-    HTML += '<b>CSAIL Group</b>: ' + group + '<br><br>';
+    HTML += '<b>CSAIL Group</b>: ' + group + '<br>';
     plain.push('CSAIL Group: ' + group); 
   }
+  
+  HTML += '<b>Categories</b>: ' + categories.join(', ') + '<br><br>';
+  plain.push('Categories: ' + categories.join(', '));
 
   var authorList = [];
   authors.split('\n').forEach(function(a){
@@ -181,6 +230,14 @@ function generateEmails(formData) {
     HTML += '<br><b>Other info</b>: ' + other;
     plain.push('\nOther info: ' + other);
   }
+  
+  var tag_line = '';
+  categories.forEach(function(c){
+    tag_line += '#' + cats[c] + ' ';
+  });
+  
+  HTML += '<br>' + tag_line + '<br>';
+  plain.push('\n' + tag_line);
 
   return {
     'HTML' : HTML,

--- a/formEmails/instructions.md
+++ b/formEmails/instructions.md
@@ -1,11 +1,14 @@
 # Sending Emails via Google Forms Submission
 
-The code in its current state does as follows:
+The code in its current state in [formSubmission.js](formSubmission.js) does as follows:
 1) Parse a response to a Google Form, which collects information about new publications by members of our lab
 2) Generate HTML and plaintext for an email containing that info
 3) Post the message to a Murmur group
+4) Send a confirmation email with an "edit response" link to the submitter
 
 You can see what our form looks like [here]() (TODO: put a link to a copy of the form here.) 
+
+The code in [logEditURL.js](logEditURL.js) is run as a script in the spreadsheet where form responses are gathered, and logs the edit URLs for each form response in the spreadsheet. 
 
 Instructions for using with your own forms:
 1) Create a Google Form with your desired questions/form fields.

--- a/formEmails/logEditURL.js
+++ b/formEmails/logEditURL.js
@@ -1,0 +1,10 @@
+// store the edit link for the form in the spreadsheet 
+function storeEditURL(e) {
+  var sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Form Responses 1');
+  var urlCol = 28;
+  var row = Math.floor(sheet.getLastRow());
+  var resIndex = row - 2;
+  var form = FormApp.openByUrl('');
+  var editLink = form.getResponses()[resIndex].getEditResponseUrl();
+  sheet.getRange(row, urlCol).setValue([editLink]);
+}


### PR DESCRIPTION
- now we send a confirmation email to the form's submitter which contains the "edit response' URL
- added fields for category to the form, and these get put as tags at the bottom of the generated email
- added new script that runs in the spreadsheet where form data is stored and logs the edit response URL for each submission
- updated instructions a bit 

turns out that we do already allow underscores, just not dashes, so I switched to using those in multi-word tags.

minus the issue with emails getting flagged as suspicious (which is bigger than just this use case) I think this should finally be ready to go.... can demo it tomorrow at meeting 