### PR TITLE
remove URL line

### DIFF
--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -76,8 +76,7 @@ urlpatterns = patterns('',
                     {'extra_context' : website_context},
                     name='password_reset_confirm'),
                        
-     (r'^accounts/', include('registration.backends.default.urls')),
-     url(r'^attachment/(?P<hash_filename>[0-9A-Za-z_]+)', 'browser.views.serve_attachment'),
+    url(r'^attachment/(?P<hash_filename>[0-9A-Za-z_]+)', 'browser.views.serve_attachment'),
 
     url(r'^accounts/activate/complete/$',
        TemplateView.as_view(template_name='registration/activation_complete.html'),


### PR DESCRIPTION
this line appears later in the file already. having it where it was breaks all of the custom registration pages that need extra context (website name)