### PR TITLE
fix error with special characters in 'from'

### DIFF
--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -816,7 +816,7 @@ def send_account_info(message, address=None, host=None):
 	logging.debug(message['To'])
 	logging.debug(message['From'])
 
-	if str(message['From']) == NO_REPLY and (activation_str in subj_string or reset_str in subj_string):
+	if message['From'].encode('utf-8') == NO_REPLY and (activation_str in subj_string or reset_str in subj_string):
 		
 		email_message = email.message_from_string(str(message))
 		msg_text = get_body(email_message)


### PR DESCRIPTION
fixes the error we found yesterday with sender names that have non-ASCII characters. 