### PR TITLE
hopefully fix decoding stuff

### DIFF
--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -231,24 +231,25 @@ def get_body(email_message):
 		res['plain'] = ''
 
 		for part in email_message.get_payload():
-			d = (part['Content-Transfer-Encoding'] == 'base64')
+			d1 = (part['Content-Transfer-Encoding'] == 'base64')
 			if part.get_content_maintype() == 'text':
 				if part.get_content_subtype() == 'html':
-					body = part.get_payload(decode=d)
+					body = part.get_payload(decode=d1)
 					body = remove_html_ps(body)
 					res['html'] += body
 				else:
-					body = part.get_payload(decode=d)
+					body = part.get_payload(decode=d1)
 					body = remove_plain_ps(body)
 					res['plain'] += body
 			elif part.get_content_maintype() == 'multipart':
+				d2 = (part2['Content-Transfer-Encoding'] == 'base64')
 				for part2 in part.get_payload():
 					if part2.get_content_subtype() == 'html':
-						body = part2.get_payload(decode=d)
+						body = part2.get_payload(decode=d2)
 						body = remove_html_ps(body)
 						res['html'] += body
 					elif part2.get_content_subtype() == 'plain':
-						body = part2.get_payload(decode=d)
+						body = part2.get_payload(decode=d2)
 						body = remove_plain_ps(body)
 						res['plain'] += body
 	elif maintype == 'text':

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -242,8 +242,8 @@ def get_body(email_message):
 					body = remove_plain_ps(body)
 					res['plain'] += body
 			elif part.get_content_maintype() == 'multipart':
-				d2 = (part2['Content-Transfer-Encoding'] == 'base64')
 				for part2 in part.get_payload():
+					d2 = (part2['Content-Transfer-Encoding'] == 'base64')
 					if part2.get_content_subtype() == 'html':
 						body = part2.get_payload(decode=d2)
 						body = remove_html_ps(body)


### PR DESCRIPTION
So as @oliverjd suggested, it is indeed lamson that is base64 encoding parts of messages before handing them off to us. I spent quite a while playing around with lamson functions and sample messages, and I *think* that the bug is happening as follows... (feel free to not read all of this, though it's mildly interesting... just wanted to thoroughly write it down in case we need to revisit later.) 

So basically, when we receive a message, Lamson first parses the message using its [from_message](https://github.com/zedshaw/lamson/blob/8a8ad546ea746b129fa5f069bf9278f87d01473a/lamson/encoding.py#L217) method and creates a new "pristine MailBase" object (recursively made up of more MailBase objects, one corresponds to each message part).
Then it converts this MailBase back to a normal Python email object using its [to_message](https://github.com/zedshaw/lamson/blob/8a8ad546ea746b129fa5f069bf9278f87d01473a/lamson/encoding.py#L248) method, and hands it off to us. The result of this is what we get passed in our routes in smtp_handler/main.py. 

So the problem happens when it calls to_message. Called for each sub-part of the message, this works as follows:
- Create an empty MIMEPart. Copy over the "content-type" header, but NOT the "content-transfer-encoding" header. (Why? I don't know.) So new MIMEPart has content-transfer-encoding "None". 
- Call [MIMEPart.extract_payload](https://github.com/zedshaw/lamson/blob/8a8ad546ea746b129fa5f069bf9278f87d01473a/lamson/encoding.py#L194) to extract the MailBase's payload and attach it to the MIMEPart. If the content type is "text/___", extract_payload then calls [MIMEPart.add_text](https://github.com/zedshaw/lamson/blob/8a8ad546ea746b129fa5f069bf9278f87d01473a/lamson/encoding.py#L182). Now this is where things go bad...
    - add_text first tries to encode as ascii. Sometimes ascii encoding fails. (Seems to happen for quoted-printable encoded message parts. Maybe other cases too.) If ascii fails with a UnicodeError, utf-8 encode instead. 
    - Now attach the encoded text to the message by calling [set_payload(encoded, charset)](https://github.com/zedshaw/lamson/blob/8a8ad546ea746b129fa5f069bf9278f87d01473a/lamson/encoding.py#L191). [When set_payload is called with a charset specified](https://docs.python.org/2/library/email.message.html#email.message.Message.set_payload), it will in turn call set_charset, which sets the message's default charset. 
        - **Key: "If there is no existing Content-Transfer-Encoding header, then the payload will be transfer-encoded, if needed, using the specified Charset, and a header with the appropriate value will be added."** 
        - Now, remember there is no content-transfer-encoding set, so this will result in encoding the payload. how does one encode the body using utf-8? lamson is going to call [get_body_encoding()](https://docs.python.org/2/library/email.charset.html#email.charset.Charset.get_body_encoding) on the utf-8 charset to find out what to use...
        ```
        >>> c = Charset('utf-8')
        >>> c.get_body_encoding()
       'base64'
       ```
        - So lamson sees this, base64-encodes the body, and sets content-transfer-encoding to base64. 

And thus these quoted-printable text segments of multipart messages end up encoded as base64. 

On the lamson side this can be fixed by setting the content-transfer-encoding header of the MIMEPart to match that of the MailBase *before* setting the payload. I don't understand why they don't do that; they only carry over the content-type headers. (this is the same reason why we had to subclass to add the quoted-printable header on our outgoing emails.) 

Although it was easy to subclass lamson to customize behavior for *outgoing* messages, I can't really figure out an easy way change what it does with incoming messages before handing them to us that doesn't require modifying code inside the lamson package itself or creating our own fork of lamson, etc. 
So it seems like for now the easiest fix is to just look out for these base64 encoded text parts and decode them when we see them. I had actually somewhat stumbled upon this solution last week with the decode=True argument, but my fix then did not deal with multipart messages where text subparts are base64 encoded but the whole message is not. 
I've tested this on the dev server with the sample garbled emails and it seems to properly decode them now. *Hopefully* this resolves things... 