### PR TITLE
logic for what happens to incoming posts

### DIFF
--- a/browser/views.py
+++ b/browser/views.py
@@ -1438,11 +1438,13 @@ def dashboard(request):
 		groups = Group.objects.filter(membergroup__member=user).values("name")
 		mod_group_count = len(Group.objects.filter(membergroup__member=user, membergroup__moderator=True))
 		res = engine.main.load_pending_posts(user)
+		pending_posts = []
 		if not res['status']:
 			logging.debug('Error loading pending posts: ' + str(res['error']))
-			pending_posts = []
 		else:
-			pending_posts = res['posts']
+			for p in res['posts']:
+				p['text'] = html2text(p['text'])
+				pending_posts.append(p)
 
 		return {'user' : request.user, 'groups' : groups, 'mod_group_count' : mod_group_count,
 				'pending_posts' : pending_posts, 'website' : WEBSITE}

--- a/engine/main.py
+++ b/engine/main.py
@@ -887,9 +887,7 @@ def _create_post(group, subject, message_text, user, sender_addr, msg_id, attach
 			f.save()
 
 	elif WEBSITE == 'squadbox':
-		# later on there will be various user options for this. for now just choose 
-		# to send to all moderators.
-		recipients = [m.member.email for m in MemberGroup.objects.filter(group=group, moderator=True)]
+		recipients = []
 		tags = None
 		tag_objs = None 
 	

--- a/schema/models.py
+++ b/schema/models.py
@@ -164,10 +164,10 @@ class Group(models.Model):
 	description = models.CharField(max_length=140)
 	public = models.BooleanField(default=True)
 	active = models.BooleanField(default=True)
-	
 	allow_attachments = models.BooleanField(default=True)
-	
 	timestamp = models.DateTimeField(auto_now=True)
+	show_rejected_site = models.BooleanField(default=True)
+	send_rejected_tagged = models.BooleanField(default=True)
 	
 	def __unicode__(self):
 		return self.name

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -475,73 +475,104 @@ def handle_post_murmur(message, group, host):
 		
 def handle_post_squadbox(message, group, host):
 
-	_, sender_addr = parseaddr(message['From'].lower())
-
-	# whitelist/blacklist checking
-	white_or_blacklist = WhiteOrBlacklist.objects.filter(group=group, email=sender_addr)
-	if white_or_blacklist.exists():
-		w_or_b = white_or_blacklist[0]
-		if w_or_b.blacklist:
-			# reject message - store in database
-			logging.debug("Sender %s blacklisted; rejecting message" % sender_addr)
-			return
-		elif w_or_b.whitelist:
-			logging.debug("Sender %s whitelisted; accepting message" % sender_addr)
-			return
-			# send message on to intended recipient (aka group admin)
-			# try:
-			# 	group_admin = MemberGroup.objects.get(group=group, admin=True)
-			# 	# 1) create new email
-			# 	# 2) send
-			# except Exception, e:
-			# 	error_msg = "Admin of group %s not found: %s" % (group.name, e)
-			# 	logging.debug(error_msg)
-			# 	send_error_email(group.name, error_msg, None, ADMIN_EMAILS)
-			# 	return
-			# pass
-
-	# TODO: should see if things are replies/add-ons to a thread (for the case where
-	# a moderator keeps following a thread due to user request)
-	subj = message['Subject'].strip()
 	msg_id = message['Message-ID']
-
 	email_message = message_from_string(str(message))
 	msg_text = get_body(email_message)
+	_, sender_addr = parseaddr(message['From'].lower())
+	subj = message['Subject'].strip()
+
 	if 'html' not in msg_text or msg_text['html'] == '':
 		msg_text['html'] = markdown(msg_text['plain'])
 	if 'plain' not in msg_text or msg_text['plain'] == '':
 		msg_text['plain'] = html2text(msg_text['html'])
 
-	res = insert_post(group.name, subj, msg_text['html'], None, sender_addr, msg_id, forwarding_list=None, post_status='P')
-	# TODO: deal with attachments here the same way they are in handle_post_murmur (and consider membergroup.receive_attachments)
-
-	if not res['status']:
-		send_error_email(group.name, res['code'], None, ADMIN_EMAILS)
-		return
-
-	moderators = res['recipients']
-	if len(moderators) == 0:
-		error_msg = 'Error: the group %s has no moderators' % group.name
-		logging.debug(error_msg)
-		send_error_email(group.name, error_msg, None, ADMIN_EMAILS)
-		# maybe here we should just send the original email on to the admin here then? 
-		return
-
-	outgoing_msg = setup_moderation_post(group.name, msg_text, res['post_id'])
-
 	attachments = get_attachments(email_message)
-	for attachment in attachments.get("attachments"):
-		outgoing_msg.attach(filename=attachment['filename'],
-				content_type=attachment['mime'],
-				data=attachment['content'],
-				disposition=attachment['disposition'],
-				id=attachment['id'])
 
-	outgoing_msg['message-id'] = res['msg_id']
+	# initially, assume that it's pending and will go through moderation. 
+	status = 'P'
 
-	for m in moderators:
-		relay.deliver(outgoing_msg, To=m)
-		logging.debug("sending msg to moderator %s" % m)
+	# if whitelisted, accept; if blacklisted, reject 
+	white_or_blacklist = WhiteOrBlacklist.objects.filter(group=group, email=sender_addr)
+	if white_or_blacklist.exists():
+		w_or_b = white_or_blacklist[0]
+		if w_or_b.blacklist:
+			status = 'R' # if blacklist could means "gets moderated", need to change. 
+		elif w_or_b.whitelist:
+			status = 'A' # sender is whitelisted, so we can accept the mesasge 
+
+	# either:
+	# 1) sender is whitelisted
+	# 2) sender is blacklisted, but the user still wants rejected messages. 
+	if status == 'A' or (status == 'R' and group.send_rejected_tagged):
+		# we can just send it on to the intended recipient, i.e. the admin of the group. 
+		mg = MemberGroup.objects.get(group=group, admin=True)
+		admin = mg.member
+
+		new_subj = subj
+		if status == 'R':
+			new_subj = '[Rejected] ' + new_subj 
+
+		mail = MurmurMailResponse(From = message['From'], To = admin.email, Subject = new_subj)
+
+		if 'references' in message:
+			mail['References'] = message['references']
+		elif 'message-id' in message:
+			mail['References'] = message['message-id']	
+	
+		if 'in-reply-to' not in message:
+			mail["In-Reply-To"] = message['message-id']
+
+		mail['message-id'] = msg_id
+		ccs = email_message.get_all('cc', None)
+		if ccs:
+			mail['Cc'] = ','.join(ccs)
+
+		for attachment in attachments.get("attachments"):
+			mail.attach(filename=attachment['filename'],
+						content_type=attachment['mime'],
+						data=attachment['content'],
+						disposition=attachment['disposition'],
+						id=attachment['id'])
+
+		if status == 'A':
+			reason = 'whitelist'
+		elif status == 'R':
+			reason = 'blacklist'
+
+		html_blurb = unicode(html_ps_squadbox(group.name, sender_addr, reason))
+		mail.Html = get_new_body(msg_text, html_blurb, 'html')
+
+		plain_blurb = plain_ps_squadbox(group.name, sender_addr, reason)
+		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
+
+		relay.deliver(mail, To = admin.email)
+
+	# send notification to mods (probably should change to not do this every time)
+	elif status == 'P':
+
+		moderators = MemberGroup.objects.filter(group=group, moderator=True)
+
+		if len(moderators) == 0:
+			error_msg = 'Error: the group %s has no moderators' % group.name
+			logging.debug(error_msg)
+			send_error_email(group.name, error_msg, None, ADMIN_EMAILS)
+			# maybe here we should just send the original email on to the admin here then? 
+			return
+
+		outgoing_msg = setup_moderation_post(group.name)
+		outgoing_msg['message-id'] = base64.b64encode(group.name + str(datetime.now())).lower() + '@' + BASE_URL
+
+		for m in moderators:
+			member = m.member
+			relay.deliver(outgoing_msg, To=member.email)
+			logging.debug("sending msg to moderator %s" % member.email)
+	
+	# if pending or rejected, we need to put it in the DB 
+	if status == 'P' or status == 'R':
+		res = insert_post(group.name, subj, msg_text['html'], None, sender_addr, msg_id, forwarding_list=None, post_status=status)
+		if not res['status']:
+			send_error_email(group.name, res['code'], None, ADMIN_EMAILS)
+			return
 
 @route("(address)@(host)", address=".+", host=HOST)
 @stateless

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -3,7 +3,7 @@ from lamson.server import Relay
 from config.settings import *
 from lamson_subclass import MurmurMailResponse
 from schema.models import Group, MemberGroup, Thread, Following, Mute
-from http_handler.settings import BASE_URL, DEFAULT_FROM_EMAIL
+from http_handler.settings import BASE_URL, DEFAULT_FROM_EMAIL, WEBSITE
 
 
 '''
@@ -53,7 +53,11 @@ PERMALINK_POST = 'http://%s/thread?tid=%s&post_id=%s'
 HTML_SUBHEAD = '<div style="border-top:solid thin;padding-top:5px;margin-top:10px">'
 HTML_SUBTAIL = '</div>'
 
-PLAIN_SUBHEAD = '***\nMurmur\n'
+if WEBSITE == 'murmur':
+	PLAIN_SUBHEAD = '***\nMurmur\n'
+elif WEBSITE == 'squadbox':
+	PLAIN_SUBHEAD = '***\nSquadbox\n'
+
 PLAIN_SUBTAIL = '\n***\n'
 
 RESERVED = ['+create', '+activate', '+deactivate', '+subscribe', '+unsubscribe', '+admins', '+info', 'help', 'no-reply', 'all', POST_SUFFIX, FOLLOW_SUFFIX, UNFOLLOW_SUFFIX, MUTE_SUFFIX, UNMUTE_SUFFIX, UPVOTE_SUFFIX, DOWNVOTE_SUFFIX, FETCH_SUFFIX]
@@ -90,9 +94,9 @@ def setup_post(From, Subject, group_name):
 	
 	return mail
 
-def setup_moderation_post(group_name, msg_text, post_id):
+def setup_moderation_post(group_name):
 
-	subject = 'Post to Squadbox group %s requires approval' % group_name 
+	subject = 'New post to Squadbox squad %s requires approval' % group_name 
 	to = '%s Moderators <%s+mods@%s>' % (group_name, group_name, HOST)
 	from_addr = 'Squadbox Notifications <%s+notifications@%s>' % (group_name, HOST)
 
@@ -105,14 +109,18 @@ def setup_moderation_post(group_name, msg_text, post_id):
 		"Precedence": 'list'
 		})
 
-	html_ps_blurb = 'replace this with a blurb later on!'
-	html_ps_blurb = unicode(html_ps_blurb)
-	mail.Html = get_new_body(msg_text, html_ps_blurb, 'html')
+	plain_body = "To view all pending posts to the squad, visit your dashboard: %s/dashboard" % BASE_URL
+	html_body = "To view all pending posts to the squad, visit your <a href='%s/dashboard'>dashboard</a>." % BASE_URL 
+
+	blurb = "You're receiving this message because you're a moderator of the squad %s." % group_name
+	html_ps_blurb = '%s%s%s' % (HTML_SUBHEAD, blurb, HTML_SUBTAIL)
+	plain_ps_blurb = '%s%s%s' % (PLAIN_SUBHEAD, blurb, PLAIN_SUBTAIL)
+
+	mail.Html = html_body + html_ps_blurb
+	mail.Body = plain_body + plain_ps_blurb
 	
-	plain_ps_blurb = 'replace this with a blurb later on!'
-	mail.Body = get_new_body(msg_text, plain_ps_blurb, 'plain')
-		
 	return mail
+
 
 def send_error_email(group_name, error, user_addr, admin_emails):
 	mail = MurmurMailResponse(From = NO_REPLY, Subject = "Error")
@@ -350,6 +358,26 @@ def plain_forwarded_blurb(group_name, to_list, original_list_email=None):
 			posts to a mailing list you are a member of (%s)." % (group_name, group_name, HOST, to_list)
 	content += "\n\nLearn more about Murmur <http://murmur.csail.mit.edu>"
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
+	return body
+
+def html_ps_squadbox(squad_name, sender, reason):
+	content = ''
+	if reason == 'whitelist':
+		content += 'This message was automatically approved by Squadbox because the sender %s is on your whitelist.' % sender
+	elif reason == 'blacklist':
+		content += 'This message was automatically rejected by Squadbox because the sender %s is on your blacklist.' % sender
+
+	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
+	return body
+
+def plain_ps_squadbox(squadbox, sender, reason):
+	content = ''
+	if reason == 'whitelist':
+		content += 'This message was automatically approved by Squadbox because the sender %s is on your whitelist.' % sender
+	elif reason == 'blacklist':
+		content += 'This message was automatically rejected by Squadbox because the sender %s is on your blacklist.' % sender
+
+	body = '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
 	return body
 
 def html_ps(group, thread, post_id, membergroup, following, muting, tag_following, tag_muting, tags, original_list_email=None):


### PR DESCRIPTION
Changes here
- the previews of posts with HTML were displaying the HTML literally, so now convert to plaintext first. 
- no longer get the squadbox recipients in insert_post, because we insert both posts that need to be moderated and those that don't (rejected ones)
- two new fields added to Group table about what should happen to rejected posts. (you'll need to do a migration - auto should be fine.) 
- sorting out logic for what happens to an incoming post
    - if sender is whitelisted, add a footer noting that, and send on to intended recipient 
    - if sender is blacklisted, put message in DB with status rejected, and if user wants rejected messages, send on with [Rejected] tag and a footer explaining why
    - otherwise, put in DB with status pending, send a notification to mods that a new message needs moderating. later on will make this fancier so they don't just get an email for every email. 

still have to write the code to send message on to the intended recipient if a mod approves it.