### PR TITLE
hopefully fix today's encoding issue...

### DIFF
--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -261,13 +261,14 @@ def get_body(email_message):
 						body = remove_plain_ps(body)
 						res['plain'] += body
 	elif maintype == 'text':
+		d = (email_message['Content-Transfer-Encoding'] == 'base64')
 		if subtype == 'html':
-			body = email_message.get_payload()
+			body = email_message.get_payload(decode=d)
 			body = remove_html_ps(body)
 			res['html'] = body
 			
 		elif subtype == 'plain':
-			body = email_message.get_payload()
+			body = email_message.get_payload(decode=d)
 			body = remove_plain_ps(body)
 			res['plain'] = body
 	return res


### PR DESCRIPTION
the issue with today's garbled message was that it was not multipart, but was still base64 encoded.  this adds an additional check for base64 encoding on single-part messages, and if it sees them, decodes accordingly. there hopefully are not any more edge cases for different combos of encodings and message parts.