### PR TITLE
Handle attachments on moderated posts

### DIFF
--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -25,11 +25,14 @@
 		{% endautoescape %}
 		</div>
 		<BR>
-		<span class="strong-gray">
-		{% for name, url in thread.post.attachments %}
-		<a href="{{url}}">{{name}}</a>
-			{% endfor %}
-		</span>
+		{% if thread.post.attachments %}
+			<b>Attachments</b>:
+			<span class="strong-gray">
+			{% for name, url in thread.post.attachments %}
+			<a href="{{url}}">{{name}}</a>
+				{% endfor %}
+			</span>
+		{% endif %}
 		<BR>
 	</div>
 	<br>

--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -26,11 +26,11 @@
 		</div>
 		<BR>
 		{% if thread.post.attachments %}
-			<b>Attachments</b>:
+			<b>Attachments</b>:<br>
 			<span class="strong-gray">
 			{% for name, url in thread.post.attachments %}
-			<a href="{{url}}">{{name}}</a>
-				{% endfor %}
+				<a href="{{url}}">{{name}}</a><br>
+			{% endfor %}
 			</span>
 		{% endif %}
 		<BR>

--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -25,6 +25,11 @@
 		{% endautoescape %}
 		</div>
 		<BR>
+		<span class="strong-gray">
+		{% for name, url in thread.post.attachments %}
+		<a href="{{url}}">{{name}}</a>
+			{% endfor %}
+		</span>
 		<BR>
 	</div>
 	<br>

--- a/engine/attachments.py
+++ b/engine/attachments.py
@@ -28,7 +28,7 @@ def upload_attachments(attachments, msg_id):
 def download_attachments(msg_id):
 
     files = []
-    attachments = Attachment.objects.filter(msg_id=p.msg_id)
+    attachments = Attachment.objects.filter(msg_id=msg_id)
     for a in attachments:
         path = a.hash_filename + '/' + a.true_filename 
         with default_storage.open(path, 'r') as f:

--- a/engine/attachments.py
+++ b/engine/attachments.py
@@ -33,7 +33,7 @@ def download_attachments(msg_id):
         path = a.hash_filename + '/' + a.true_filename 
         with default_storage.open(path, 'r') as f:
             file = {
-                'name' : true_filename,
+                'name' : a.true_filename,
                 'data' : f.read()
             }
             files.append(file)

--- a/engine/attachments.py
+++ b/engine/attachments.py
@@ -24,3 +24,17 @@ def upload_attachments(attachments, msg_id):
             a = Attachment(msg_id=msg_id, hash_filename=hash_filename, true_filename=filename)
             a.save()
     return res
+
+def download_attachments(msg_id):
+
+    files = []
+    attachments = Attachment.objects.filter(msg_id=p.msg_id)
+    for a in attachments:
+        path = a.hash_filename + '/' + a.true_filename 
+        with default_storage.open(path, 'r') as f:
+            file = {
+                'name' : true_filename,
+                'data' : f.read()
+            }
+            files.append(file)
+    return files

--- a/engine/main.py
+++ b/engine/main.py
@@ -8,7 +8,7 @@ from lamson.mail import MailResponse
 from smtp_handler.utils import *
 from bleach import clean
 from cgi import escape
-from attachments import upload_attachments
+from attachments import upload_attachments, download_attachments
 import re
 import hashlib
 import random
@@ -1461,7 +1461,9 @@ def update_post_status(user, group_name, post_id, new_status):
 				mail = MailResponse(From = p.poster_email, To = admin.email, Subject = new_subj)
 				mail['message-id'] = p.msg_id
 
-				# TODO: need to readd attachments here...
+				attachments = download_attachments(p.msg_id)
+				for a in attachments:
+					mail.attach(filename=a['name'], data=a['data'])
 
 				html_blurb = unicode(html_ps_squadbox(group_name, p.poster_email, reason))
 				plain_blurb = plain_ps_squadbox(group_name, p.poster_email, reason)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -569,7 +569,7 @@ def handle_post_squadbox(message, group, host):
 	
 	# if pending or rejected, we need to put it in the DB 
 	if status == 'P' or status == 'R':
-		res = insert_post(group.name, subj, msg_text['html'], None, sender_addr, msg_id, forwarding_list=None, post_status=status)
+		res = insert_post(group.name, subj, msg_text['html'], None, sender_addr, msg_id, attachments, None, status)
 		if not res['status']:
 			send_error_email(group.name, res['code'], None, ADMIN_EMAILS)
 			return


### PR DESCRIPTION
when a post goes through moderation and is approved, we grab its attachments back from AWS and put them on the outgoing message. 