### PR TITLE
more moderation features

### DIFF
--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -36,12 +36,51 @@
 		<BR>
 	</div>
 	<br>
-	<div class='text-center'>
-	<input type="checkbox" id='whitelist-check'>Add sender {{thread.post.from}} to whitelist</input><br>
-	<input type="checkbox" id='blacklist-check'>Add sender {{thread.post.from}} to blacklist</input><br>
+
+	<div class='text-center' style='text-align:center;'>
+	
+	<label class="radio-inline"><input type="radio" id="approve-radio" name="approve-reject" value="approve">Approve</label>
+	<label class="radio-inline"><input type="radio" id="reject-radio" name="approve-reject" value="reject">Reject</label>
+	<br><br>
+
+
+	<div id="ifApprove" style='display:none'>
+		<input type="checkbox" id='whitelist-check'> Add sender {{thread.post.from}} to whitelist</input> 
+		<span data-toggle="tooltip" title="Emails from {{thread.post.from}} will automatically be approved in the future.">&#9432;</span>
+		<br>
+	</div>
+
+	<div id="ifReject" style='display:none;'>
+		<label for="textarea">Reason for rejection</label><br>
+		<textarea name="" id="explanation" style='width:500px; height: 100px;'></textarea>
+		<br><br>
+
+		<label for="tags">This message contains:</label>
+		<table id="tags" style='margin: 0 auto;'>
+			<tr>
+				<td>Profanity</td>
+				<td><input type="checkbox" class="tag-checks" value='profanity'></input></td>
+			</tr>
+			<tr>
+				<td>Threats</td>
+				<td><input type="checkbox" class="tag-checks" value='threat'></input></td>
+			</tr>
+			<tr>
+				<td>Explicit content</td>
+				<td><input type="checkbox" class="tag-checks" value='explicit'></input></td>
+			</tr>
+			<tr>
+				<td>Insults</td>
+				<td><input type="checkbox" class="tag-checks" value='insult'></input></td>
+			</tr>
+		</table>
+		<br><br>
+		<input type="checkbox" id='blacklist-check'> Add sender {{thread.post.from}} to blacklist</input>
+		<span data-toggle="tooltip" title="Emails from {{thread.post.from}} will automatically be rejected in the future.">&#9432;</span>
+		<br>
+	</div>
 	<br>
-	<button type="button" id="btn-approve" style="margin: 5px; background-color:#28850f; border:none;">Approve</button>
-	<button type="button" id="btn-reject" style="margin: 5px; background-color:#a52312; border:none;">Reject</button>
+	<button type="button" id="btn-submit">Submit</button>
 	</div>
 
 {% endblock %}

--- a/browser/views.py
+++ b/browser/views.py
@@ -1,52 +1,33 @@
-import base64
-from engine.constants import *
-from browser.util import load_groups
-from browser.util import paginator
-from lamson.mail import MailResponse
-from smtp_handler.utils import *
-from http_handler.settings import WEBSITE, AWS_STORAGE_BUCKET_NAME, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
-
-from django.core.context_processors import csrf
-import json, logging
-from django.shortcuts import render_to_response, get_object_or_404, redirect
+import base64, json, logging
 
 from annoying.decorators import render_to
-from schema.models import UserProfile, Group, MemberGroup, Tag, FollowTag,\
-	MuteTag, ForwardingList, Attachment, Post
+from boto.s3.connection import S3Connection
 from html2text import html2text
-from django.contrib.auth.forms import AuthenticationForm
-from registration.forms import RegistrationForm
-
-import json
-import logging
+from lamson.mail import MailResponse
 
 from django.conf import global_settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm
 from django.core.context_processors import csrf
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
 from django.db.models.aggregates import Count
 from django.http import *
 from django.shortcuts import get_object_or_404, redirect, render_to_response
 from django.template.context import RequestContext
 from django.utils.encoding import *
-from html2text import html2text
-from lamson.mail import MailResponse
-from registration.forms import RegistrationForm
 
-import engine.main
 from browser.util import load_groups, paginator
+import engine.main
 from engine.constants import *
-from http_handler.settings import WEBSITE
+from http_handler.settings import WEBSITE, AWS_STORAGE_BUCKET_NAME, AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+from registration.forms import RegistrationForm
 from schema.models import (FollowTag, ForwardingList, Group, MemberGroup, MemberGroupPending,
-                           MuteTag, Tag, UserProfile, Post)
+                           MuteTag, Tag, UserProfile, Post, Attachment)
 from smtp_handler.utils import *
 
-from django.core.files.storage import default_storage
-from django.core.files.base import ContentFile
-
-from boto.s3.connection import S3Connection
-
 request_error = json.dumps({'code': msg_code['REQUEST_ERROR'],'status':False})
+
 if WEBSITE == 'murmur':
 	group_or_squad = 'group'
 elif WEBSITE == 'squadbox':
@@ -1294,7 +1275,9 @@ def reject_post(request):
 			user = get_object_or_404(UserProfile, email=request.user.email)
 			group_name = request.POST['group_name']
 			post_id = request.POST['post_id']
-			res = engine.main.update_post_status(user, group_name, post_id, 'R')
+			explanation = request.POST['explanation']
+			tags = request.POST['tags']
+			res = engine.main.update_post_status(user, group_name, post_id, 'R', explanation=explanation, tags=tags)
 			return HttpResponse(json.dumps(res), content_type="application/json")
 	except Exception, e:
 		print e

--- a/engine/main.py
+++ b/engine/main.py
@@ -1426,7 +1426,7 @@ def update_blacklist_whitelist(user, group_name, email, whitelist, blacklist):
 	logging.debug(res)
 	return res 
 
-def update_post_status(user, group_name, post_id, new_status):
+def update_post_status(user, group_name, post_id, new_status, explanation=None, tags=None):
 	res = {'status' : False}
 
 	try:
@@ -1440,6 +1440,22 @@ def update_post_status(user, group_name, post_id, new_status):
 			res['code'] = msg_code['INVALID_STATUS_ERROR'] % new_status
 		else:
 			p.status = new_status
+			p.who_moderated = user
+
+			if explanation is not None:
+				p.mod_explanation = explanation
+
+			group_tag_names = [t.tag.name for t in TagThread.objects.filter(thread=p.thread)]
+
+			if len(tags) > 0:
+				tag_names = tags.split(',')
+				for t in tag_names:
+					if t not in group_tag_names:
+						_create_tag(g, p.thread, t)
+
+			if new_status == 'R' and 'rejected' not in group_tag_names:
+				_create_tag(g, p.thread, 'rejected')
+
 			p.save()
 			res['status'] = True
 			res['post_id'] = post_id
@@ -1448,15 +1464,26 @@ def update_post_status(user, group_name, post_id, new_status):
 			# now send message on to the intended recipient if it was approved,
 			# or if it was rejected but the recipient wants rejected emails with tag
 			if new_status == 'A' or (new_status == 'R' and g.send_rejected_tagged):
-				mg = MemberGroup.objects.get(group=g, admin=True)
-				admin = mg.member
+
+
+				mgs = MemberGroup.objects.filter(group=g, admin=True)
+				if not mgs.exists():
+					return res
+				else: 
+					admin = mgs[0].member
 
 				if new_status == 'A':
-					new_subj = p.subject
 					reason = 'approved by moderator %s.' % user.email
 				elif new_status == 'R':
-					new_subj = "[Rejected] " + p.subject
 					reason = 'rejected by moderator %s.' % user.email
+
+				tags = [t.tag.name for t in TagThread.objects.filter(thread = p.thread)]
+
+				subject_tags = ''
+				for t in tags:
+					subject_tags += '[%s]' % t
+
+				new_subj = subject_tags + ' ' + p.subject
 
 				mail = MailResponse(From = p.poster_email, To = admin.email, Subject = new_subj)
 				mail['message-id'] = p.msg_id
@@ -1468,8 +1495,12 @@ def update_post_status(user, group_name, post_id, new_status):
 				html_blurb = unicode(html_ps_squadbox(group_name, p.poster_email, reason))
 				plain_blurb = plain_ps_squadbox(group_name, p.poster_email, reason)
 
-				message_text = {'html' : p.post}
-				message_text['plain'] = html2text(p.post)
+				html_prefix = ''
+				if new_status == 'R' and len(p.mod_explanation) > 0:
+					html_prefix = "<p><b>Moderator explanation for rejection</b>: %s </p><b>Message text</b>:<br>" % p.mod_explanation
+
+				message_text = {'html' : html_prefix + p.post}
+				message_text['plain'] = html2text(html_prefix + p.post)
 				mail.Html = get_new_body(message_text, html_blurb, 'html')
 				mail.Body = get_new_body(message_text, plain_blurb, 'plain')
 				relay_mailer.deliver(mail, To = admin.email)

--- a/http_handler/static/css/squadbox/base.css
+++ b/http_handler/static/css/squadbox/base.css
@@ -105,7 +105,9 @@ hr{
 
 .group-container {
 	margin:0px auto;
-	margin-top:70px;
+	margin-top:40px;
+	margin-left: 100px;
+	margin-right: 100px;
 	padding:30px; 
 	vertical-align:top;
 	background-color: rgba(183, 233, 250, 0.5);
@@ -658,4 +660,13 @@ strong {
 h2 {
 	margin-top: 0;
 	padding-bottom: 10px;
+}
+
+table {
+  border-collapse: separate;
+  border-spacing: 10px 0;
+}
+
+td {
+  padding: 0px 10px;
 }

--- a/schema/models.py
+++ b/schema/models.py
@@ -10,7 +10,7 @@ from http_handler.settings import AUTH_USER_MODEL
 
 class Post(models.Model):
 	id = models.AutoField(primary_key=True)
-	author = models.ForeignKey(settings.AUTH_USER_MODEL, null=True)
+	author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='user_authored_posts', null=True)
 	subject = models.TextField()
 	msg_id = models.CharField(max_length=120, unique=True)
 	post = models.TextField()
@@ -27,8 +27,17 @@ class Post(models.Model):
 	# fwds to this Murmur group
 	poster_email = models.EmailField(max_length=255, null=True)
 
+	# moderation-related data 
+
+	# what state a message is currently in 
 	STATUS_CHOICES = (('R', 'rejected'), ('P', 'pending'), ('A', 'approved'))
 	status = models.CharField(max_length=1, choices=STATUS_CHOICES, default='A')
+
+	# optional explanation from mod about decision
+	mod_explanation = models.TextField(null=True)
+
+	# who the moderator that approved or rejected this message was
+	who_moderated = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='user_moderated_posts', null=True)
 
 	def __unicode__(self):
 		if self.author:


### PR DESCRIPTION
- added some extra post metadata fields to schema - auto migration should be fine. 
- depending on whether approve or reject is selected, show mod different additional options 
    - if accept, mod can add sender to whitelist
    - if reject, mod can add sender to blacklist, write an explanation, and/or add (for now) generic tags about content
- backend support for the tag and explanation features
- cleaned up duplicate logging statements (maybe from an auto-merge) in views.py
