### PR TITLE
front-end support for rejected message settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ schema/migrations/*
 
 # Google secrets file
 gmail_setup/client_secrets.json
+http_handler/static/css/fonts/glyphicons-halflings-regular.woff2
+
+http_handler/static/css/fonts/glyphicons-halflings-regular.ttf
+
+http_handler/static/css/fonts/glyphicons-halflings-regular.svg
+
+http_handler/static/css/fonts/glyphicons-halflings-regular.eot
+
+http_handler/static/css/fonts/glyphicons-halflings-regular.woff

--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,3 @@ schema/migrations/*
 
 # Google secrets file
 gmail_setup/client_secrets.json
-http_handler/static/css/fonts/glyphicons-halflings-regular.woff2
-
-http_handler/static/css/fonts/glyphicons-halflings-regular.ttf
-
-http_handler/static/css/fonts/glyphicons-halflings-regular.svg
-
-http_handler/static/css/fonts/glyphicons-halflings-regular.eot
-
-http_handler/static/css/fonts/glyphicons-halflings-regular.woff

--- a/browser/templates/create_group.html
+++ b/browser/templates/create_group.html
@@ -44,9 +44,20 @@
 		{% if website == "murmur" %}
 		Users will not be able to post attachments. Messages with attachments will be rejected.
 		{% elif website == "squadbox" %}
-		Emails that reach your Squadbox with attachments will automically be rejected. 
+		Emails that reach your Squadbox with attachments will automatically be rejected. 
 		{% endif %}
 		</span>
+		{% if website == "squadbox" %}
+			<br>
+			<span class="strong">Rejected Messages: </span> <br>
+			<input type="checkbox" id="send-rejected"> Send me rejected messages with a <b>[rejected]</b> tag in the subject line</input><br>
+			<span class="italic-small"><a href="/static/filters/tag_archive_rejected.xml" download>Download a Gmail filter to automatically sort these messages into a separate folder</a> (<a href="">Gmail filters tutorial</a>)</span>
+			<input type="checkbox" id="store-rejected"> Store rejected messages on the Squadbox website</input>
+			<span class="italic-small">We will store messages that your moderators reject, and display a link to view them on your homepage.</span>
+			<br>
+		{% endif %}
+
+
 		<br/>
 		<button type="button" id="btn-new-create-group" style="margin-top:10px;">Create</button>
 	</form>

--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -1,35 +1,33 @@
 {% extends "group_container_base.html" %}
 {% block container-content %}
 	<p hidden id='group-name'>{{group_info.name}}</p>
-	<h3>Edit {{ group_or_squad | title }} Information</h3>
+	<h3>Edit {{ group_or_squad | title }} Information and Settings</h3>
 	<hr/>
 	<form id="group-info-form">
 		<span class="strong">{{ group_or_squad | title }} Name:</span>
-		<br/>
+		<br>
 		<span class="italic-med">
 			Maximum 20 characters. Only alphanumeric characters, underscores, and dashes allowed.
 		</span>
-		<br/>
+		<br>
 		<input id="edit-group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;" value="{{group_info.name}}">
 		</input>
-		<br/><br/>
-		<span class="strong">{{ group_or_squad | title }} Description:</span> <br/>
-		<span class="italic-med">Maximum 140 characters</span><br/>
+		<br><br>
+		<span class="strong">{{ group_or_squad | title }} Description:</span> <br>
+		<span class="italic-med">Maximum 140 characters</span><br>
 		<textarea id="edit-group-description" maxlength="140">{{group_info.description.strip }}</textarea>
-		<br/><br/>
+		<br><br>
 		{% if website == "murmur" %}
 			<span class="strong">Privacy Settings:</span>
-			<br/>
+			<br>
 			{% if group_info.public %}
 				<input type="radio" name="pubpriv" value="public" id="rdo-pub-create-group" checked>
 			{% else %}
 				<input type="radio" name="pubpriv" value="public" id="rdo-pub-create-group">
 			{% endif %}
-
 			Public
-			<br/>
+			<br>
 			<span class="italic-small">All Murmur users will be able to view and search for this group by name and description.</span>
-
 			{% if group_info.public %}
 				<input type="radio" name="pubpriv" value="private" id="rdo-priv-create-group">
 			{% else %}
@@ -37,22 +35,22 @@
 			{% endif %}
 			
 			Private
-			<br/>
+			<br>
 			<span class="italic-small">Only users added to this group by admins will be notified about the group.</span>
-			<br/>
+			<br>
 		{% endif %}
-		<span class="strong">Attachment Policy: </span> <br/>
+		<span class="strong">Attachment Policy: </span> <br>
 		{% if group_info.allow_attachments %}
 			<input type="radio" name="attach" value="yes-attach" id="rdo-attach-create-group" checked>
 		{% else %}
 			<input type="radio" name="attach" value="yes-attach" id="rdo-attach-create-group">
 		{% endif %}
 		Allow Attachments
-		<br/>
+		<br>
 		<span class="italic-small">
 			{% if website == "murmur" %}
 				All members of the group can post attachments. Size of attachments cannot exceed 3MB. We currently support images, PDFs, and MS Office files.
-			{% elif website == "squadbox" %}
+				{% elif website == "squadbox" %}
 				Emails with attachments that reach your Squadbox will be moderated as usual. Your squad's moderators will be able to see them when they review messages, and you'll see the attachments on approved messages. Size of attachments cannot exceed 3MB. We currently support images, PDFs, and MS Office files.
 			{% endif %}
 		</span>
@@ -62,25 +60,31 @@
 			<input type="radio" name="attach" value="no-attach" id="rdo-attach-create-group" checked>
 		{% endif %}
 		No Attachments Allowed
-		<br/>
+		<br>
 		<span class="italic-small">
 			{% if website == "murmur" %}
 				Users will not be able to post attachments. Messages with attachments will be rejected.
-				{% elif website == "squadbox" %}
-				Emails that reach your Squadbox with attachments will automically be rejected.
+			{% elif website == "squadbox" %}
+				Emails that reach your Squadbox with attachments will automatically be rejected.
 			{% endif %}
 		</span>
-		<br/>
+		
+		{% if website == "squadbox" %}
+			<br>
+			<span class="strong">Rejected Messages: </span> <br>
+			<input type="checkbox" id="send-rejected-check"> Send me rejected messages with a <b>[rejected]</b> tag in the subject line</input><br>
+			<span class="italic-small"><a href="/static/filters/tag_archive_rejected.xml" download>Download a Gmail filter to automatically sort these messages into a separate folder</a> (<a href="">Gmail filters tutorial</a>)</span>
+			<input type="checkbox" id="store-rejected-check"> Store rejected messages on the Squadbox website</input>
+			<span class="italic-small">We will store messages that your moderators reject, and display a link to view them on your homepage.</span>
+			<br>
+		{% endif %}
+		<br>
 		<button type="button" id="btn-save-settings" style="margin-top:10px;">Save Changes</button>
 		<button type="button" id="btn-cancel-settings" style="margin-top:10px;">Cancel</button>
 	</form>
-	<br/>
-
-	{% if website == 'squadbox' %}
-		<h4><a href='/gmail_setup?group={{group_info.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a></h4>
-	{% endif %}
-	{% endblock %}
-	{% block customjs %}
-		<script type="text/javascript" src="/static/javascript/notify.js"></script>
-		<script type="text/javascript" src="/static/javascript/edit_group_info.js"></script>
-	{% endblock %}
+	<br>
+{% endblock %}
+{% block customjs %}
+	<script type="text/javascript" src="/static/javascript/notify.js"></script>
+	<script type="text/javascript" src="/static/javascript/edit_group_info.js"></script>
+{% endblock %}

--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -50,7 +50,7 @@
 		<span class="italic-small">
 			{% if website == "murmur" %}
 				All members of the group can post attachments. Size of attachments cannot exceed 3MB. We currently support images, PDFs, and MS Office files.
-				{% elif website == "squadbox" %}
+			{% elif website == "squadbox" %}
 				Emails with attachments that reach your Squadbox will be moderated as usual. Your squad's moderators will be able to see them when they review messages, and you'll see the attachments on approved messages. Size of attachments cannot exceed 3MB. We currently support images, PDFs, and MS Office files.
 			{% endif %}
 		</span>
@@ -72,17 +72,28 @@
 		{% if website == "squadbox" %}
 			<br>
 			<span class="strong">Rejected Messages: </span> <br>
-			<input type="checkbox" id="send-rejected-check"> Send me rejected messages with a <b>[rejected]</b> tag in the subject line</input><br>
+			{% if group_info.send_rejected_tagged %}
+			<input type="checkbox" id="send-rejected" checked> 
+			{% else %}
+			<input type="checkbox" id="send-rejected">
+			{% endif %}
+			 Send me rejected messages with a <b>[rejected]</b> tag in the subject line</input><br>
 			<span class="italic-small"><a href="/static/filters/tag_archive_rejected.xml" download>Download a Gmail filter to automatically sort these messages into a separate folder</a> (<a href="">Gmail filters tutorial</a>)</span>
-			<input type="checkbox" id="store-rejected-check"> Store rejected messages on the Squadbox website</input>
+			{% if group_info.show_rejected_site %}
+			<input type="checkbox" id="store-rejected" checked>
+			{% else %}
+			<input type="checkbox" id="store-rejected">
+			{% endif %}
+			Store rejected messages on the Squadbox website</input>
 			<span class="italic-small">We will store messages that your moderators reject, and display a link to view them on your homepage.</span>
 			<br>
 		{% endif %}
 		<br>
-		<button type="button" id="btn-save-settings" style="margin-top:10px;">Save Changes</button>
-		<button type="button" id="btn-cancel-settings" style="margin-top:10px;">Cancel</button>
+		<button type="button" id="btn-save-settings"">Save Changes</button>
+		<button type="button" id="btn-cancel-settings">Cancel</button>
 	</form>
 	<br>
+	<a href="/groups/{{group_info.name}}">&#171; Go back to squad info page</a>
 {% endblock %}
 {% block customjs %}
 	<script type="text/javascript" src="/static/javascript/notify.js"></script>

--- a/browser/templates/squadbox/add_members.html
+++ b/browser/templates/squadbox/add_members.html
@@ -2,18 +2,18 @@
 
 {% block container-content %}
 	
-	<h3>Add New Members to <span id="group-name">{{ group_info.name }}</span></h3>
+	<h3>Invite new moderators to <span id="group-name">{{ group_info.name }}</span></h3>
 	<hr />
 	
 	<form id="new-members-form">
-		<span class="strong">Moderators</span>: Will review moderated emails before you see them. If they don't have accounts, we will create new ones for them. Enter email addresses, separated by commas:<br />
+		<span class="strong">Moderators</span> will review emails before you see them. If they don't have Squadbox accounts, we will create them. <br><br>Enter email addresses, separated by commas: <br>
 		<input id="new-member-emails" type="text" style="width: 100%; box-sizing: border-box;"></input>
-		<br /> <br />
-		<button type="button" id="btn-add-members" style="margin-top:10px;">Add Members</button>
+		<br><br>
+		<button type="button" id="btn-add-members" style="margin-top:10px;">Invite</button>
 	</form>
-	<br /><br />
+	<br>
 	
-	<a href="/groups/{{group_info.name}}">Squad Info Page</a>
+	<a href="/groups/{{group_info.name}}">Back to squad info page</a>
 {% endblock %}
 
 {% block customjs %}

--- a/browser/templates/squadbox/edit_my_settings.html
+++ b/browser/templates/squadbox/edit_my_settings.html
@@ -1,26 +1,17 @@
 {% extends "group_container_base.html" %}
-
 {% block container-content %}
-<h3>Edit My Settings for <span id="group-name">{{ group_info.name }}</span></h3><hr /><br />
-<form id="group-settings-form">
-	<h4>Customizing Emails: </h4> <br/>
+	<h3>Edit My Settings for <span id="group-name">{{ group_info.name }}</span></h3><hr><br>
+	<form id="group-settings-form">
+		<h4>Customizing Emails: </h4><br>
+		<button type="button" id="btn-save-settings" style="margin-top:10px;">Save Settings</button>
+		<button type="button" id="btn-cancel-settings" style="margin-top:10px;">Cancel</button>
+	</form>
 	
-			<button type="button" id="btn-save-settings" style="margin-top:10px;">Save Settings</button>
-			<button type="button" id="btn-cancel-settings" style="margin-top:10px;">Cancel</button>
-		</form>
-		
-		<br/><br/>
-		
-		<a href="/groups/{{group_info.name}}">Squad Info Page</a>
-		
-		{% if settings.receive_attachments %}
-			<input type="checkbox" name="receive-attachments" value="yes" id="ck-receive-attachments" checked>
-		{% else %}
-			<input type="checkbox" name="receive-attachments" value="no" id="ck-receive-attachments">
-		{% endif %}
-		Receive attachments with emails.
-		<br /><br />
-		
+	<br><br>
+	
+	<a href="/groups/{{group_info.name}}">Squad Info Page</a>
+	
+	
 {% endblock %}
 {% block customjs %}
 	<script type="text/javascript" src="/static/javascript/squadbox/my_group_settings.js"></script>

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -150,6 +150,10 @@
 					</tbody>
 				</table>
 				<br />
+				<hr>
+				<h3>Whitelist/Blacklist</h3>
+				<a href='/gmail_setup?group={{group_info.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
+				<hr>
 				{% if group_info.admin %}
 					<div style="text-align:center">
 						<button type="button" class="btn btn-danger" id="btn-delete-group">Delete squad</button>

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -152,7 +152,7 @@
 				<br />
 				<hr>
 				<h3>Whitelist/Blacklist</h3>
-				<a href='/gmail_setup?group={{group_info.group.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
+				<a href='/gmail_setup?group={{group_info.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
 				<hr>
 				{% if group_info.admin %}
 					<div style="text-align:center">

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -34,20 +34,20 @@
 				Attachments <span class="strong">are allowed</span>.
 			{% endif %}
 
-			{% if website == "squadbox" %}
-				<br>
-				{% if not group_info.group.send_rejected_tagged %}
-					Rejected messages <span class="strong">will not</span> be sent to your inbox.
-				{% else %}
-					Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
-				{% endif %}
-				<br>
-				{% if not group_info.group.show_rejected_site %}
-					Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
-				{% else %}
-					Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
-				{% endif %}
+
+			<br>
+			{% if not group_info.group.send_rejected_tagged %}
+				Rejected messages <span class="strong">will not</span> be sent to your inbox.
+			{% else %}
+				Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
 			{% endif %}
+			<br>
+			{% if not group_info.group.show_rejected_site %}
+				Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
+			{% else %}
+				Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
+			{% endif %}
+
 			<br><br>
 			
 			<div id="group-options">

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -27,10 +27,26 @@
 			{% endif %}
 			
 			<br><br>
+
 			{% if not group_info.group.allow_attachments %}
 				<span class="strong">No Attachments</span> are allowed.
 			{% else %}
 				Attachments <span class="strong">are allowed</span>.
+			{% endif %}
+
+			{% if website == "squadbox" %}
+				<br>
+				{% if not group_info.group.send_rejected_tagged %}
+					Rejected messages <span class="strong">will not</span> be sent to your inbox.
+				{% else %}
+					Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
+				{% endif %}
+				<br>
+				{% if not group_info.group.show_rejected_site %}
+					Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
+				{% else %}
+					Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
+				{% endif %}
 			{% endif %}
 			<br><br>
 			

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -6,12 +6,6 @@
 	<div class="container">
 		<div class="group-container">
 			
-			{% if group_info.subscribed %}
-				<span class="member label">Member</span>
-			{% else %}
-				<span class="member label" style="display: none;"></span>
-			{% endif %}
-			
 			{% if group_info.admin %}
 				<span class="admin label">Admin</span>
 			{% else %}
@@ -32,82 +26,41 @@
 				<span class="italic-med">{{ group_info.group.description }}</span>
 			{% endif %}
 			
-			<br/><br/>
-
-				{% if not group_info.group.allow_attachments %}
-					<span class="strong">No Attachments</span> are allowed.
+			<br><br>
+			{% if not group_info.group.allow_attachments %}
+				<span class="strong">No Attachments</span> are allowed.
+			{% else %}
+				Attachments <span class="strong">are allowed</span>.
+			{% endif %}
+			<br><br>
+			
+			<div id="group-options">
+				{% if group_info.subscribed %}
+					<!-- 						<button type="button" id="btn-edit-settings">Edit My Settings</button> -->
+					{% if group_info.admin %}
+						<button type="button" id="btn-edit-group-info">Edit settings</button>
+					{% endif %}
+					<br /><br />
 				{% else %}
-					Attachments <span class="strong">are allowed</span>.
+					<button type="button" id="btn-edit-settings" style="display: none;">Edit My Settings</button>
 				{% endif %}
-				<br />
-				You can contact the squad's administrators at <a href="mailto:{{admin_address}}" target="_newtab">{{admin_address}}</a>.
-				<br />
-				<br />
 				
-				<a href="/posts?group_name={{ group_info.group.name }}">View Posts</a> <br /> <br />
-				
-				<div id="group-options">
-					{% if group_info.subscribed %}
-						<button type="button" id="btn-edit-settings">Edit My Settings</button>
-						{% if group_info.admin %}
-							<button type="button" id="btn-edit-group-info">Edit Squad Information</button>
-						{% endif %}
-						<br /><br />
-					{% else %}
-						<button type="button" id="btn-edit-settings" style="display: none;">Edit My Settings</button>
-					{% endif %}
-					
-					{% if group_info.admin %}
-						{% if group_info.group.active %}
-							<button type="button" id="btn-deactivate-group">De-Activate</button>
-							<button type="button" id="btn-activate-group" style="display: none;">Activate</button>
-						{% else %}
-							<button type="button" id="btn-deactivate-group" style="display: none;">De-Activate</button>
-							<button type="button" id="btn-activate-group">Activate</button>
-						{% endif %}
-					{% else %}
-						<button type="button" id="btn-deactivate-group" style="display: none;">De-Activate</button>
-						<button type="button" id="btn-activate-group" style="display: none;">Activate</button>
-					{% endif %}
-					
-					{% if group_info.subscribed %}
-						<button type="button" id="btn-unsubscribe-group">Un-Subscribe</button>
-						<button type="button" id="btn-subscribe-group" style="display: none;">Subscribe</button>
-					{% else %}
-						<button type="button" id="btn-unsubscribe-group" style="display: none;">Un-Subscribe</button>
-						<button type="button" id="btn-subscribe-group">Subscribe</button>
-					{% endif %}
-					{% if group_info.admin %}
-						<button type="button" id="btn-delete-group">Delete Squad</button>
-					{% endif %}
-				</div>
-				<br />
-				<hr />
-				{% if group_info.admin %}
+				{% if group_info.subscribed and not group_info.admin %}
+					<button type="button" id="btn-unsubscribe-group">Leave squad</button>
+				{% endif %}
+			</div>
+			
+			<hr />
+			{% if group_info.admin %}
 				<h3>Squad Members</h3>
-
-					<button type="button" id="btn-add-members">Add Members</button>
-					<button type="button" id="btn-del-members">Delete Members</button>
-					<button type="button" id="btn-set-admin">Set as Admin</button>
-					<button type="button" id="btn-set-mod">Set as Moderator</button>
-				{% else %}
-					<button type="button" id="btn-add-members" style="display: none;">Add Members</button>
-				{% endif %}
-				{% if group_info.admin %}
-					<table id="members-table" class="display" cellspacing="0" width="100%">
-						<thead>
-							<tr>
-								<th>Select</th>
-								<th>Email</th>
-								{% if flavour != "mobile" %}
-									<th>Joined</th>
-									<th>Admin</th>
-									<th>Moderator</th>
-								{% endif %}
-							</tr>
-						</thead>
-						
-						<tfoot>
+				<button type="button" id="btn-add-members">Invite new moderators</button>
+				<button type="button" id="btn-del-members">Remove selected</button>
+			{% else %}
+				<button type="button" id="btn-add-members" style="display: none;">Add Members</button>
+			{% endif %}
+			{% if group_info.admin %}
+				<table id="members-table" class="display" cellspacing="0" width="100%">
+					<thead>
 						<tr>
 							<th>Select</th>
 							<th>Email</th>
@@ -117,35 +70,31 @@
 								<th>Moderator</th>
 							{% endif %}
 						</tr>
-						</tfoot>
-						
-						<tbody>
-							{% for member in group_info.members %}
-								
-								{% if member.email == user.email %}
-									<tr class="my_row">
-									{% else %}
-										<tr>
-										{% endif %}
-										
-										{% if group_info.admin %}
-											<td><input class="checkbox checkbox-user" type="checkbox" id ={{ member.id }}></td>
-											<td>{{ member.email }}</td>
-											{% if flavour != "mobile" %}
-												<td>{{ member.joined }}</td>
-												{% if member.admin %}
-													<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
-												{% else %}
-													<th></th>
-												{% endif %}
-												{% if member.mod %}
-													<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
-												{% else %}
-													<th></th>
-												{% endif %}
-											{% endif %}
-										</tr>
-									{% else %}
+					</thead>
+					
+					<tfoot>
+					<tr>
+						<th>Select</th>
+						<th>Email</th>
+						{% if flavour != "mobile" %}
+							<th>Joined</th>
+							<th>Admin</th>
+							<th>Moderator</th>
+						{% endif %}
+					</tr>
+					</tfoot>
+					
+					<tbody>
+						{% for member in group_info.members %}
+							
+							{% if member.email == user.email %}
+								<tr class="my_row">
+								{% else %}
+									<tr>
+									{% endif %}
+									
+									{% if group_info.admin %}
+										<td><input class="checkbox checkbox-user" type="checkbox" id ={{ member.id }}></td>
 										<td>{{ member.email }}</td>
 										{% if flavour != "mobile" %}
 											<td>{{ member.joined }}</td>
@@ -161,104 +110,55 @@
 											{% endif %}
 										{% endif %}
 									</tr>
-								{% endif %}
-							{% endfor %}
-							{% for member in group_info.members_pending %}
-								<tr>
-									<td></td>
-									<td><i>{{ member.email }} (pending)</i></td>
-										{% if flavour != "mobile" %}
-											<td>{{ member.joined }}</td>
-											{% if member.admin %}
-												<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
-											{% else %}
-												<th></th>
-											{% endif %}
-											{% if member.mod %}
-												<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
-											{% else %}
-												<th></th>
-											{% endif %}
+								{% else %}
+									<td>{{ member.email }}</td>
+									{% if flavour != "mobile" %}
+										<td>{{ member.joined }}</td>
+										{% if member.admin %}
+											<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
+										{% else %}
+											<th></th>
 										{% endif %}
+										{% if member.mod %}
+											<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
+										{% else %}
+											<th></th>
+										{% endif %}
+									{% endif %}
 								</tr>
-							{% endfor %}
-						</tbody>
-					</table>
-					<br />
-					<hr />
-					<h3>Associated Mailing Lists</h3>
-					
-					<button type="button" id="btn-add-list">Add List</button>
-					<select id='actionSelect'>
-						<option value='label' selected="true">Other actions</option>
-						<option value="deleteList">Delete</option>
-						<option value="addPost">Make Poster</option>
-						<option value="addReceive">Make Recipient</option>
-						<option value="removePost">Remove as Poster</option>
-						<option value="removeReceive">Remove as Recipient</option>
-					</select>
-					
-					<table id="lists-table" class="display" cellspacing="0" width="100%">
-						<thead>
+							{% endif %}
+						{% endfor %}
+						{% for member in group_info.members_pending %}
 							<tr>
-								<th>Select</th>
-								<th>Email</th>
+								<td></td>
+								<td><i>{{ member.email }} (pending)</i></td>
 								{% if flavour != "mobile" %}
-									<th>Added</th>
-									<th>Can Post</th>
-									<th>Can Receive</th>
-									<th>List URL</th>
-								</tr>
-							</thead>
-							
-							<tfoot>
-							<tr>
-								<th>Select</th>
-								<th>Email</th>
-								{% if flavour != "mobile" %}
-									<th>Added</th>
-									<th>Can Post</th>
-									<th>Can Receive</th>
-									<th>List URL</th>
+									<td>{{ member.joined }}</td>
+									{% if member.admin %}
+										<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
+									{% else %}
+										<th></th>
+									{% endif %}
+									{% if member.mod %}
+										<th><span class="glyphicon glyphicon-ok" aria-hidden="true"></span></th>
+									{% else %}
+										<th></th>
+									{% endif %}
 								{% endif %}
 							</tr>
-							</tfoot>
-							
-							
-							<tbody>
-								{% for l in group_info.lists %}
-									<tr>
-										<td><input class="checkbox checkbox-list" type="checkbox" id ={{ l.email }}></td>
-										<td>{{ l.email }}</td>
-										{% if flavour != "mobile" %}
-											<td>{{ l.added }}</td>
-											<th>
-												{% if l.can_post %}
-													<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-												{% endif %}
-											</th>
-											<th>
-												{% if l.can_receive %}
-													<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-												{% endif %}
-											</th>
-											
-											<td>
-												{% if l.url != None %}
-													<a href=//{{l.url}}>{{ l.url }}</a>
-												{% endif %}
-											</td>
-											
-										{% endif %}
-									</tr>
-								{% endfor %}
-							</tbody>
-						</table>
+						{% endfor %}
+					</tbody>
+				</table>
+				<br />
+				{% if group_info.admin %}
+					<div style="text-align:center">
+						<button type="button" class="btn btn-danger" id="btn-delete-group">Delete squad</button>
+					</div>
 				{% endif %}
-				</div>
 			</div>
-		{% endif %}
-	{% endblock %}
-	{% block customjs %}
-		<script type="text/javascript" src="/static/javascript/squadbox/group_page.js"></script>
-	{% endblock %}
+		</div>
+	{% endif %}
+{% endblock %}
+{% block customjs %}
+	<script type="text/javascript" src="/static/javascript/squadbox/group_page.js"></script>
+{% endblock %}

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -152,7 +152,7 @@
 				<br />
 				<hr>
 				<h3>Whitelist/Blacklist</h3>
-				<a href='/gmail_setup?group={{group_info.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
+				<a href='/gmail_setup?group={{group_info.group.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
 				<hr>
 				{% if group_info.admin %}
 					<div style="text-align:center">

--- a/browser/views.py
+++ b/browser/views.py
@@ -469,7 +469,9 @@ def create_group(request):
 		user = get_object_or_404(UserProfile, email=request.user.email)
 		public = request.POST['public'] == 'public'
 		attach = request.POST['attach'] == 'yes-attach'
-		res = engine.main.create_group(request.POST['group_name'], request.POST['group_desc'], public, attach, user)
+		send_rejected = request.POST['send_rejected_tagged'] == 'true'
+		store_rejected = request.POST['store_rejected'] == 'true'
+		res = engine.main.create_group(request.POST['group_name'], request.POST['group_desc'], public, attach, send_rejected, store_rejected, user)
 		return HttpResponse(json.dumps(res), content_type="application/json")
 	except Exception, e:
 		print e

--- a/browser/views.py
+++ b/browser/views.py
@@ -428,7 +428,9 @@ def edit_group_info(request):
 		group_desc = request.POST['group_desc'] 
 		public = request.POST['public'] == 'public'
 		attach = request.POST['attach'] == 'yes-attach'
-		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, user) 
+		send_rejected = request.POST['send_rejected_tagged'] == 'true'
+		store_rejected = request.POST['store_rejected'] == 'true'
+		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, user) 
 		if res['status']:
 			active_group = request.session.get('active_group')
 			if active_group == old_group_name:

--- a/engine/main.py
+++ b/engine/main.py
@@ -229,7 +229,11 @@ def create_group(group_name, group_desc, public, attach, requester):
 		group = Group(name=group_name, active=True, public=public, allow_attachments=attach, description=group_desc)
 		group.save()
 		
-		membergroup = MemberGroup(group=group, member=requester, admin=True, moderator=True)
+		is_mod = True
+		if WEBSITE == 'squadbox':
+			is_mod = False
+
+		membergroup = MemberGroup(group=group, member=requester, admin=True, moderator=is_mod)
 		membergroup.save()
 		
 		res['status'] = True

--- a/engine/main.py
+++ b/engine/main.py
@@ -205,7 +205,7 @@ def edit_members_table(group_name, toDelete, toAdmin, toMod, user):
 	logging.debug(res)
 	return res
 
-def create_group(group_name, group_desc, public, attach, requester):
+def create_group(group_name, group_desc, public, attach, send_rejected, store_rejected, requester):
 	res = {'status':False}
 	
 	
@@ -226,7 +226,7 @@ def create_group(group_name, group_desc, public, attach, requester):
 		res['code'] = msg_code['DUPLICATE_ERROR']
 		
 	except Group.DoesNotExist:
-		group = Group(name=group_name, active=True, public=public, allow_attachments=attach, description=group_desc)
+		group = Group(name=group_name, active=True, public=public, allow_attachments=attach, send_rejected_tagged=send_rejected, show_rejected_site=store_rejected, description=group_desc)
 		group.save()
 		
 		is_mod = True

--- a/engine/main.py
+++ b/engine/main.py
@@ -243,7 +243,7 @@ def create_group(group_name, group_desc, public, attach, requester):
 	logging.debug(res)
 	return res
 
-def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, user):
+def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, user):
 	res = {'status':False}	
 	try:
 		group = Group.objects.get(name=old_group_name)
@@ -252,6 +252,8 @@ def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, 
 		group.description = group_desc
 		group.public = public
 		group.allow_attachments = attach
+		group.send_rejected_tagged = send_rejected
+		group.show_rejected_site = store_rejected
 		group.save()
 		res['status'] = True	
 	except Group.DoesNotExist:

--- a/http_handler/static/css/squadbox/base.css
+++ b/http_handler/static/css/squadbox/base.css
@@ -553,10 +553,6 @@ textarea {
 	box-shadow: 1px 0px 3px #666;
 }
 
-#members-table {
-	background: #D7ECFA;
-}
-
 
 #highlight_post {
 	background-color: #FFF7CE;

--- a/http_handler/static/filters/tag_archive_rejected.xml
+++ b/http_handler/static/filters/tag_archive_rejected.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?><feed xmlns='http://www.w3.org/2005/Atom' xmlns:apps='http://schemas.google.com/apps/2006'>
+	<entry>
+		<category term='filter'></category>
+		<title>Label and Archive Rejected</title>
+		<apps:property name='subject' value='[rejected]'/>
+		<apps:property name='label' value='rejected'/>
+		<apps:property name='shouldArchive' value='true'/>
+	</entry>
+</feed>

--- a/http_handler/static/javascript/create_group.js
+++ b/http_handler/static/javascript/create_group.js
@@ -9,8 +9,13 @@ $(document).ready(function() {
         params.group_desc = $("#new-group-description").val();
         if (website == "squadbox") { // all squads private 
             params.public = false;
+            params.send_rejected_tagged = $('#send-rejected')[0].checked;
+            params.store_rejected = $('#store-rejected')[0].checked;
         } else if (website == "murmur") {
             params.public = $('input[name=pubpriv]:checked', '#new-group-form').val();
+            // just go with the defaults for these for now
+            params.send_rejected_tagged = true;
+            params.store_rejected = true;
         }
         params.attach = $('input[name=attach]:checked', '#new-group-form').val();
 

--- a/http_handler/static/javascript/edit_group_info.js
+++ b/http_handler/static/javascript/edit_group_info.js
@@ -22,8 +22,14 @@ $(document).ready(function() {
 
         if (website == "squadbox") { // all squads private 
             params.public = false;
+            params.send_rejected_tagged = $('#send-rejected')[0].checked;
+            params.store_rejected = $('#store-rejected')[0].checked;
         } else if (website == "murmur") {
             params.public = $('input[name=pubpriv]:checked', '#group-info-form').val();
+
+            // just go with the defaults for these for now
+            params.send_rejected_tagged = true;
+            params.store_rejected = true;
         }
 
         $.post('/edit_group_info', params,


### PR DESCRIPTION
- upon creation and also in squad settings page, let admin set per-group/squad settings for whether rejected messages are sent out with a tag, and whether they are stored on the site 
- some reorganizing and cleanup on squad settings page
- added a shareable gmail filter for labeling + archiving messages with "[rejected]" in subject line 