### PR TITLE
ability to turn off squadbox

### DIFF
--- a/browser/templates/squadbox/base.html
+++ b/browser/templates/squadbox/base.html
@@ -59,15 +59,24 @@
         {% if user.is_authenticated %}
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
+	        <li>
+	          <a href="/dashboard">Moderation Queue</a>
+	        </li>
 
-	            <li class="dropdown dropdown-left">
-	              <a href="/dashboard">Moderation Queue</a>
-	            </li>
-	            <li class="dropdown dropdown-left">
-	              <a href="/my_group_list">Manage Squads</a>
-	            </li>
+            <li class="dropdown">
+            	<a href="#" class="dropdown-toggle" data-toggle="dropdown">Rejected Posts<span class="caret"></span></a>
+              <ul class="dropdown-menu" role="menu">
+                {% for group in groups %}
+	                	<li><a href="/groups/{{ group.name }}/rejected">{{ group.name }}</a></li>
+					{% endfor %}
+              </ul>
+            </li>
 
+            <li>
+	          <a href="/my_group_list">Manage Squads</a>
+	        </li>
           </ul>
+
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown dropdown-right">
             	<a href="#" class="dropdown-toggle" data-toggle="dropdown"><span id="user_email">{{ user.email|truncatechars:20 }}</span><span class="caret"></span></a>

--- a/browser/templates/squadbox/base.html
+++ b/browser/templates/squadbox/base.html
@@ -14,6 +14,7 @@
 	
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i|Permanent+Marker" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Quicksand:400|Raleway:300,600" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Hind:400"" rel="stylesheet">
 	
 	<link rel="apple-touch-icon" sizes="57x57" href="/static/images/squadbox/favicon/apple-icon-57x57.png">
 	<link rel="apple-touch-icon" sizes="60x60" href="/static/images/squadbox/favicon/apple-icon-60x60.png">
@@ -58,48 +59,14 @@
         {% if user.is_authenticated %}
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav">
-          	
-          	{% if not group_page %}
+
 	            <li class="dropdown dropdown-left">
-	              <a href="#" class="dropdown-toggle" data-toggle="dropdown">My Squads <span class="caret"></span></a>
-	              <ul class="dropdown-menu" role="menu">
-	              	{% for group in groups %}
-	                	<li><a href="/groups/{{ group.name }}">{{ group.name }}</a></li>
-					{% endfor %}
-	                <li class="divider"></li>
-	                <li><a href="/my_group_list">Manage my squads</a></li>
-	                <li><a href="/create_new_group">Create a new squad</a></li>
-	              </ul>
+	              <a href="/dashboard">Moderation Queue</a>
+	            </li>
+	            <li class="dropdown dropdown-left">
+	              <a href="/my_group_list">Manage Squads</a>
 	            </li>
 
-            {% else %}
-<!--             	<li class="dropdown dropdown-left">
-            	{% if groups %}
-	              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><span>View Posts</span><span class="caret"></span></a>
-	            {% else %}
-	              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><span>No Squads Yet</span><span class="caret"></span></a>
-	            {% endif %}
-	              	<ul class="dropdown-menu" role="menu" id="list-group-names">
-		              	{% for group in groups %}
-		              		{% if group.name == active_group %}
-		              			<li><a href="/posts?group_name={{ group.name }}"><span id="active_group">{{ group.name }}</span></a></li>
-		              		{% else %}
-		                		<li><a href="/posts?group_name={{ group.name }}">{{ group.name }}</a></li>
-		                	{% endif %}
-						{% endfor %}
-	                <li class="divider"></li>
-	                <li><a href="/my_group_list">Manage my squads</a></li>
-	                <li><a href="/create_new_group">Create a new squad</a></li>
-	              </ul>
-	            </li> -->
-            	{% if my_groups %}
-            		<li class="active"><a href="/my_group_list">My Squads</a></li>
-            		<!-- <li><a href="/group_list">Join Squads</a></li> -->
-            	{% else %}
-            		<li><a href="/my_group_list">My Squads</a></li>
-            		<!-- <li class="active"><a href="/group_list">Explore Squads</a></li> -->
-				{% endif %}
-            {% endif %}
           </ul>
           <ul class="nav navbar-nav navbar-right">
             <li class="dropdown dropdown-right">
@@ -110,7 +77,7 @@
               </ul>
             </li>
           </ul>
-        </div><!--/.nav-collapse -->
+        </div>
         
         {% else %}
         <div class="navbar-collapse collapse">

--- a/browser/templates/squadbox/base.html
+++ b/browser/templates/squadbox/base.html
@@ -14,7 +14,7 @@
 	
 	<link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i|Permanent+Marker" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Quicksand:400|Raleway:300,600" rel="stylesheet">
-	<link href="https://fonts.googleapis.com/css?family=Hind:400"" rel="stylesheet">
+	<link href="https://fonts.googleapis.com/css?family=Hind:400,600"" rel="stylesheet">
 	
 	<link rel="apple-touch-icon" sizes="57x57" href="/static/images/squadbox/favicon/apple-icon-57x57.png">
 	<link rel="apple-touch-icon" sizes="60x60" href="/static/images/squadbox/favicon/apple-icon-60x60.png">

--- a/browser/templates/squadbox/dashboard.html
+++ b/browser/templates/squadbox/dashboard.html
@@ -1,8 +1,8 @@
 {% extends "group_container_base.html" %}
 
 {% block container-content %}
-<h3><b>Pending Emails</b></h3>
 <div id="post-column-area-wrapper">
+<h3><b>Moderation Queue</b></h3>
 	<div id="post-column-area">
 		<div class="post-list-container">
 			{% if groups|length == 0 %}
@@ -12,23 +12,29 @@
 			{% elif pending_posts|length == 0 %}
 				There are no pending emails in any squads you moderate.
 			{% else %}
-				<i>Click on an email to view its full text, and approve or reject it.</i><BR><BR>
+				<i>Click on an email to view its full text, and approve or reject it.</i><br><br>
 			{% endif %}
 
 			<ul id="post-list-table">
 				{% for post in pending_posts %}
 				<a href="/thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
 					<li class="row-item" id="{{ post.thread_id }}">
-						<div class="left-column-area-metadata">
-							<span class="gray">{{ post.timestamp|date:"n/j/Y" }}</span>
-							<span class="gray">{{ post.timestamp|date:"h:i A" }}</span>
-						</div>
-						<div class="middle-column-area-content">
-							<span class="strong">{{ post.subject }}</span>
-							<br />
-							<span class="strong-gray">{{ post.from }}</span><br />
-							<span class="blurb ellipsis">{{ post.text }}
+
+<!-- 						<span class="strong-gray">{{ post.from_name }}</span><br> -->
+						<div class="container">
+							<div class="row">
+							<div class="col-md-2">
+							<span class="strong">
+								{% if post.from_name %}
+									{{ post.from_name }}
+								{% else %}
+									{{ post.from }}
+								{% endif %}
 							</span>
+							</div>
+							<div class="col-md-4"><div class="truncate"><span class="strong">{{ post.subject }}</span> - <span class="faded-message">{{ post.text }}</span></div></div>
+							<div class="col-md-3"><div class="pull-right" style="padding-right: 20px;">{{ post.timestamp|date:"n/j/Y" }} at {{ post.timestamp|date:"h:i A" }}</div></div>
+							</div>
 						</div>
 					</li>
 				</a>
@@ -40,5 +46,4 @@
 {% endblock %}
 
 {% block customjs %}
-<!-- <script src="/static/javascript/pagination.js"></script> -->
 {% endblock %}

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -27,28 +27,28 @@
 			{% endif %}
 			
 			<br><br>
+			
+			{% if group_info.admin %}
+				{% if not group_info.group.allow_attachments %}
+					<span class="strong">No Attachments</span> are allowed.
+				{% else %}
+					Attachments <span class="strong">are allowed</span>.
+				{% endif %}
 
-			{% if not group_info.group.allow_attachments %}
-				<span class="strong">No Attachments</span> are allowed.
-			{% else %}
-				Attachments <span class="strong">are allowed</span>.
+				<br>
+				{% if not group_info.group.send_rejected_tagged %}
+					Rejected messages <span class="strong">will not</span> be sent to your inbox.
+				{% else %}
+					Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
+				{% endif %}
+				<br>
+				{% if not group_info.group.show_rejected_site %}
+					Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
+				{% else %}
+					Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
+				{% endif %}
+				<br><br>
 			{% endif %}
-
-
-			<br>
-			{% if not group_info.group.send_rejected_tagged %}
-				Rejected messages <span class="strong">will not</span> be sent to your inbox.
-			{% else %}
-				Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
-			{% endif %}
-			<br>
-			{% if not group_info.group.show_rejected_site %}
-				Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
-			{% else %}
-				Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
-			{% endif %}
-
-			<br><br>
 			
 			<div id="group-options">
 				{% if group_info.subscribed %}

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -29,6 +29,19 @@
 			<br><br>
 			
 			{% if group_info.admin %}
+				{% if group_info.active %}
+					<button id='activate-btn'>Deactivate</button> <span data-toggle="tooltip" title="When your squad is deactivated, emails will be automatically approved. You can reactivate your squad at any time.">&#9432;</span>
+				{% else %}
+					<button id='activate-btn'>Activate</button> <span data-toggle="tooltip" title="When your squad is active, emails that aren't from a whitelisted or blacklisted sender will go through moderation before they're sent to you.">&#9432;</span>
+				{% endif %}
+				<br><br>
+
+				{% if group_info.active %}
+					Your squad is currently <span class="strong">active</span>.
+				{% else %}
+					Your squad is currently <span class="strong">deactivated</span>.
+				{% endif %}
+				<br>
 				{% if not group_info.group.allow_attachments %}
 					<span class="strong">No Attachments</span> are allowed.
 				{% else %}

--- a/browser/templates/squadbox/rejected.html
+++ b/browser/templates/squadbox/rejected.html
@@ -9,7 +9,7 @@
 				{% endif %}
 				<ul id="post-list-table">
 					{% for post in rejected_posts %}
-						<a href="/thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
+						<a href="/rejected_thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
 							<li class="row-item" id="{{ post.thread_id }}">
 								<div class="container">
 									<div class="row">
@@ -22,7 +22,7 @@
 												{% endif %}
 											</span>
 										</div>
-										<div class="col-md-4"><div class="truncate"><span class="strong">{{ post.subject }}</span> - <span class="faded-message">{{ post.text }}</span></div></div>
+										<div class="col-md-4"><div class="truncate"><span class="strong">{{ post.subject }}</span></div></div>
 										<div class="col-md-3"><div class="pull-right" style="padding-right: 20px;">{{ post.timestamp|date:"n/j/Y" }} at {{ post.timestamp|date:"h:i A" }}</div></div>
 									</div>
 								</div>

--- a/browser/templates/squadbox/rejected.html
+++ b/browser/templates/squadbox/rejected.html
@@ -1,20 +1,14 @@
 {% extends "group_container_base.html" %}
 {% block container-content %}
 	<div id="post-column-area-wrapper">
-		<h3><b>Moderation Queue</b></h3>
+		<h3>Emails rejected from your squad {{ group_name }}</h3>
 		<div id="post-column-area">
 			<div class="post-list-container">
-				{% if groups|length == 0 %}
-					You are not in any squads yet. <a href="/create_new_group">Create a new squad.</a>
-					{% elif mod_group_count == 0 %}
-					You aren't a moderator for any squads yet.
-					{% elif pending_posts|length == 0 %}
-					There are no pending emails in any squads you moderate.
-				{% else %}
-					<i>Click on an email to view its full text, and approve or reject it.</i><br><br>
+				{% if rejected_posts|length == 0 %}
+					No posts have been rejected.
 				{% endif %}
 				<ul id="post-list-table">
-					{% for post in pending_posts %}
+					{% for post in rejected_posts %}
 						<a href="/thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
 							<li class="row-item" id="{{ post.thread_id }}">
 								<div class="container">

--- a/browser/templates/squadbox/rejected.html
+++ b/browser/templates/squadbox/rejected.html
@@ -1,12 +1,16 @@
 {% extends "group_container_base.html" %}
 {% block container-content %}
 	<div id="post-column-area-wrapper">
+	<div hidden id='group-name'>{{ group_name }}</div>
 		<h3>Emails rejected from your squad {{ group_name }}</h3>
 		<div id="post-column-area">
 			<div class="post-list-container">
 				{% if rejected_posts|length == 0 %}
-					No posts have been rejected.
-				{% endif %}
+					No posts have been rejected yet.
+				{% else %}
+				<div style='margin-bottom: 10px;'>
+				<button type='button' id='delete-btn' class="btn-danger">Delete</button>
+				</div>
 				<ul id="post-list-table">
 					{% for post in rejected_posts %}
 						<a href="/rejected_thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
@@ -14,6 +18,7 @@
 								<div class="container">
 									<div class="row">
 										<div class="col-md-2">
+										<input type="checkbox" style='margin-right: 5px;' value='delete-{{post.thread_id}}-{{post.id}}'>
 											<span class="strong">
 												{% if post.from_name %}
 													{{ post.from_name }}
@@ -30,9 +35,12 @@
 						</a>
 					{% endfor %}
 				</ul>
+			{% endif %}
 			</div>
 		</div>
 	</div>
 {% endblock %}
 {% block customjs %}
+<script type="text/javascript" src="/static/javascript/notify.js"></script>
+<script type="text/javascript" src="/static/javascript/squadbox/rejected.js"></script>
 {% endblock %}

--- a/browser/templates/squadbox/rejected_thread.html
+++ b/browser/templates/squadbox/rejected_thread.html
@@ -1,22 +1,28 @@
 {% extends "group_container_base.html" %}
-
 {% block container-content %}
 	<div class="main-area-content">
-	<div hidden id='group-name'>{{ active_group.name }} </div>
-	<div hidden id='post-id'>{{ thread.post.id }}</div>
-	<div hidden id='sender-email'>{{ thread.post.from }}</div>
+		<div hidden id='group-name'>{{ active_group.name }} </div>
+		<div hidden id='post-id'>{{ thread.post.id }}</div>
+		<div hidden id='sender-email'>{{ thread.post.from }}</div>
 		<div>
 			<div>
-				<h3><span id="post-subject">{{ thread.post.subject }}</span></h3>
-				<span class="strong">From: </span> 
+				<h3>
+				<span id="post-subject">{{ thread.post.subject }}</span>
+				{% for tag in thread.tags %}
+				<span class="label tag-label pull-right" style="background-color: #{{ tag.color }};">{{tag.name}}</span>
+				{% endfor %}
+				</h3>
+				<span class="strong">From: </span>
 				<span class="strong-gray" id="post-from">{{ thread.post.from }} </span>
 				{% if thread.post.verified %}
-					<span class="verified" title="The message has been verified as being sent by this email server.">&#10004;</span>
+					<span class='verified glyphicon glyphicon-ok'></span>
 				{% else %}
-					<span class="not-verified" title="We could not verify the sender\'s identity - be cautious!">&#9888;</span>
+					<span class="not-verified glyphicon glyphicon-warning-sign"></span>
 				{% endif %}
-				<br><span class="strong">To: </span>
-				<span class="strong-gray">{{ active_group.name }}</span> 
+				<br>
+				<span class="strong">To: </span>
+				<span class="strong-gray">{{ thread_to }}</span>
+				<span class="strong-gray">{{ active_group.name }}</span>
 				<br>
 				<span class="strong">Date: </span>
 				<span class="strong-gray">{{ thread.post.timestamp }}</span>
@@ -24,34 +30,42 @@
 			</div>
 		</div>
 		<hr>
-		<div>			
+		<div id="post-text" style="display: none;">
 		{% autoescape off %}
-		{{ thread.post.text }}
+			{{ thread.post.text }}
 		{% endautoescape %}
+		<br><br>
 		</div>
-		<br>
-		{% if thread.post.attachments %}
-			<b>Attachments</b>:<br>
-			<span class="strong-gray">
+		<button type="button" id="show-msg">Show message text</button>
+	<br>
+	{% if thread.post.attachments %}
+		<b>Attachments</b>:<br>
+		<span class="strong-gray">
 			{% for name, url in thread.post.attachments %}
 				<a href="{{url}}">{{name}}</a><br>
 			{% endfor %}
-			</span>
-		{% endif %}
-		<br>
-	</div>
+		</span>
+	{% endif %}
 	<br>
-	This post was rejected by moderator <a href="mailto:name@email.com">{{ thread.post.who_moderated.email }}</a>.
-	{% if thread.post.mod_explanation %}
+</div>
+<br>
+This post was rejected by moderator {{ thread.post.who_moderated.email }}.
+{% if thread.post.mod_explanation %}
 	<br><br>
 	<b>Explanation</b>: {{ thread.post.mod_explanation }}
-	{% endif %}
+	<br><br>
+{% endif %}
 
+<div id='notify-link'>Should this message have been approved? <a id="message-link">Click here to fix it, and notify the moderator</a>.</div>
+<div id='message-form' style='display: none;'>
+	<textarea id="admin-message" style='width:500px; height: 100px;' placeholder="Message to the mod..."></textarea><br>
+	<input type="checkbox" id="change-to-approve" checked> Change post status to "approved" <br>
+	<input type="checkbox">Email me the original message
+	<div style='text-align: center;'><button type="button" id='send-btn'>Send</button> <button type="button" id='cancel-btn'>Cancel</button></div>
+</div>
 {% endblock %}
-
-
 {% block customjs %}
-	<script type="text/javascript" src="/static/javascript/notify.js"></script>
-	<script type="text/javascript" src="/static/javascript/third-party/jquery-ui.min.js"></script>
-<!-- 	<script type="text/javascript" src="/static/javascript/squadbox/thread.js"></script> -->
+<script type="text/javascript" src="/static/javascript/notify.js"></script>
+<script type="text/javascript" src="/static/javascript/third-party/jquery-ui.min.js"></script>
+<script type="text/javascript" src="/static/javascript/squadbox/rejected_thread.js"></script>
 {% endblock %}

--- a/browser/templates/squadbox/rejected_thread.html
+++ b/browser/templates/squadbox/rejected_thread.html
@@ -1,0 +1,57 @@
+{% extends "group_container_base.html" %}
+
+{% block container-content %}
+	<div class="main-area-content">
+	<div hidden id='group-name'>{{ active_group.name }} </div>
+	<div hidden id='post-id'>{{ thread.post.id }}</div>
+	<div hidden id='sender-email'>{{ thread.post.from }}</div>
+		<div>
+			<div>
+				<h3><span id="post-subject">{{ thread.post.subject }}</span></h3>
+				<span class="strong">From: </span> 
+				<span class="strong-gray" id="post-from">{{ thread.post.from }} </span>
+				{% if thread.post.verified %}
+					<span class="verified" title="The message has been verified as being sent by this email server.">&#10004;</span>
+				{% else %}
+					<span class="not-verified" title="We could not verify the sender\'s identity - be cautious!">&#9888;</span>
+				{% endif %}
+				<br><span class="strong">To: </span>
+				<span class="strong-gray">{{ active_group.name }}</span> 
+				<br>
+				<span class="strong">Date: </span>
+				<span class="strong-gray">{{ thread.post.timestamp }}</span>
+				<input type="hidden" id="post_info" name="post_info" value="{{ thread.post.msg_id }}" readonly>
+			</div>
+		</div>
+		<hr>
+		<div>			
+		{% autoescape off %}
+		{{ thread.post.text }}
+		{% endautoescape %}
+		</div>
+		<br>
+		{% if thread.post.attachments %}
+			<b>Attachments</b>:<br>
+			<span class="strong-gray">
+			{% for name, url in thread.post.attachments %}
+				<a href="{{url}}">{{name}}</a><br>
+			{% endfor %}
+			</span>
+		{% endif %}
+		<br>
+	</div>
+	<br>
+	This post was rejected by moderator <a href="mailto:name@email.com">{{ thread.post.who_moderated.email }}</a>.
+	{% if thread.post.mod_explanation %}
+	<br><br>
+	<b>Explanation</b>: {{ thread.post.mod_explanation }}
+	{% endif %}
+
+{% endblock %}
+
+
+{% block customjs %}
+	<script type="text/javascript" src="/static/javascript/notify.js"></script>
+	<script type="text/javascript" src="/static/javascript/third-party/jquery-ui.min.js"></script>
+<!-- 	<script type="text/javascript" src="/static/javascript/squadbox/thread.js"></script> -->
+{% endblock %}

--- a/browser/templates/squadbox/rejected_thread.html
+++ b/browser/templates/squadbox/rejected_thread.html
@@ -1,9 +1,10 @@
 {% extends "group_container_base.html" %}
 {% block container-content %}
 	<div class="main-area-content">
-		<div hidden id='group-name'>{{ active_group.name }} </div>
+		<div hidden id='group-name'>{{ group_name }}</div>
 		<div hidden id='post-id'>{{ thread.post.id }}</div>
 		<div hidden id='sender-email'>{{ thread.post.from }}</div>
+		<div hidden id='thread-id'>{{ thread.post.thread_id }}</div>
 		<div>
 			<div>
 				<h3>
@@ -63,7 +64,11 @@ This post was rejected by moderator {{ thread.post.who_moderated.email }}.
 	<input type="checkbox">Email me the original message
 	<div style='text-align: center;'><button type="button" id='send-btn'>Send</button> <button type="button" id='cancel-btn'>Cancel</button></div>
 </div>
+<br>
+<br>
+<div style='text-align: center;'><button type="button" class='btn-danger' id='delete-btn' style='display: inline;'>Delete permanently</button></div>
 {% endblock %}
+
 {% block customjs %}
 <script type="text/javascript" src="/static/javascript/notify.js"></script>
 <script type="text/javascript" src="/static/javascript/third-party/jquery-ui.min.js"></script>

--- a/browser/views.py
+++ b/browser/views.py
@@ -840,10 +840,9 @@ def insert_reply(request):
 			group = Group.objects.get(name=group_name)
 			original_group_object = ForwardingList.objects.get(email=original_group, group=group)
 
-		res = engine.main.insert_reply(group_name, 'Re: ' + orig_subject, msg_text, user, user.email, msg_id, forwarding_list=original_group_object, thread_id=thread_id)
-		
+		res = engine.main.insert_reply(group_name, 'Re: ' + orig_subject, msg_text, user, user.email, msg_id, True, forwarding_list=original_group_object, thread_id=thread_id)
+
 		if(res['status']):
-			
 			to_send =  res['recipients']
 			post_addr = '%s <%s>' %(group_name, group_name + '@' + HOST)
 			

--- a/engine/main.py
+++ b/engine/main.py
@@ -1485,7 +1485,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 
 			group_tag_names = [t.tag.name for t in TagThread.objects.filter(thread=p.thread)]
 
-			if len(tags) > 0:
+			if tags is not None and len(tags) > 0:
 				tag_names = tags.split(',')
 				for t in tag_names:
 					if t not in group_tag_names:

--- a/engine/main.py
+++ b/engine/main.py
@@ -832,6 +832,30 @@ def load_post(group_name, thread_id, msg_id):
 	logging.debug(res)
 	return res
 
+def delete_post(user, post_id, thread_id):
+	res = {'status':False}
+	try:
+		group = Post.objects.get(id=post_id).group
+		membergroup = MemberGroup.objects.get(group=group, member=user)
+		if membergroup.admin:
+			if thread_id != u'0':
+				thread = Thread.objects.get(id=thread_id)
+				posts = Post.objects.filter(thread=thread)
+				for post in posts:
+					post.delete()
+				thread.delete()
+				res['status'] = True
+			else:
+				post = Post.objects.get(id=post_id)
+				post.delete()
+				res['status'] = True
+		else:
+			res['code'] = msg_code['PRIVILEGE_ERROR']
+	except:
+		res['code'] = msg_code['UNKNOWN_ERROR']
+	logging.debug(res)
+	return res
+
 
 def _create_tag(group, thread, name):
 	t, created = Tag.objects.get_or_create(group=group, name=name)

--- a/engine/main.py
+++ b/engine/main.py
@@ -1530,8 +1530,8 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				for a in attachments:
 					mail.attach(filename=a['name'], data=a['data'])
 
-				html_blurb = unicode(html_ps_squadbox(group_name, p.poster_email, reason))
-				plain_blurb = plain_ps_squadbox(group_name, p.poster_email, reason)
+				html_blurb = unicode(ps_squadbox(p.poster_email, reason, True))
+				plain_blurb = ps_squadbox(p.poster_email, reason, False)
 
 				html_prefix = ''
 				if new_status == 'R' and len(p.mod_explanation) > 0:

--- a/engine/main.py
+++ b/engine/main.py
@@ -792,7 +792,7 @@ def load_thread(t, user=None, member=None):
 			'thread_id': t.id, 
 		    'post': post, 
 		    'replies': replies, 
-		    'tags': json.dumps(tags),
+		    'tags': tags,
 		    'following': following, 
 		    'muting': muting,
 		    'member': is_member,

--- a/engine/main.py
+++ b/engine/main.py
@@ -132,7 +132,11 @@ def check_admin(user, groups):
 def list_my_groups(user):
 	res = {'status':False}
 	try:
-		membergroup = MemberGroup.objects.filter(member=user, group__active=True).select_related()
+		if WEBSITE == 'murmur':
+			membergroup = MemberGroup.objects.filter(member=user, group__active=True).select_related()
+		else:
+			# still want to show deactivated squads
+			membergroup = MemberGroup.objects.filter(member=user).select_related()
 		res['status'] = True
 		res['groups'] = []
 		for mg in membergroup:

--- a/engine/main.py
+++ b/engine/main.py
@@ -61,6 +61,7 @@ def group_info_page(user, group_name):
 		res['admin'] = False
 		res['moderator'] = False
 		res['subscribed'] = False
+		res['active'] = group.active
 		
 		for membergroup in members:
 			

--- a/http_handler/static/css/squadbox/base.css
+++ b/http_handler/static/css/squadbox/base.css
@@ -3,9 +3,25 @@ body, html {
 	padding-top: 50px;
 }
 
+title {
+	font-family: 'Hind', sans-serif;
+}
+
 #home-body, #home-html {
 	font-family: 'Raleway', sans-serif;
 	padding-top: 0px;
+}
+
+
+.truncate {
+  width: 440px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.faded-message {
+	color: #727F8C;
 }
 
 hr{
@@ -62,8 +78,7 @@ hr{
 }
 
 #site-name, #user_email, #email_dropdown, #groups_dropdown {
-	font-family: 'Quicksand', sans-serif;
-	font-weight: bold;
+	font-family: 'Hind', sans-serif;
 }
 
 #login-form, #reg-form {
@@ -100,7 +115,7 @@ hr{
 	vertical-align:top;
 	background-color: rgba(183, 233, 250, 0.5);
 	max-width:380px;
-	font-family: 'Raleway', sans-serif;
+	font-family: 'Hind', sans-serif;
 }
 
 .group-container {
@@ -111,7 +126,7 @@ hr{
 	padding:30px; 
 	vertical-align:top;
 	background-color: rgba(183, 233, 250, 0.5);
-	font-family: 'Raleway', sans-serif;
+	font-family: 'Hind', sans-serif;
 }
 
 .group-container-posts {

--- a/http_handler/static/css/squadbox/base.css
+++ b/http_handler/static/css/squadbox/base.css
@@ -680,11 +680,18 @@ table {
 
 td {
   padding: 0px 10px;
-  
+} 
+
 .verified {
-	color: green;
+	color: #3b8118;
 }
 
 .not-verified {
-	color: red;
+	color: #e05c5c;
+}
+
+.tag-label {
+	position: relative; 
+	top: -3px;
+	font-family: sans-serif;
 }

--- a/http_handler/static/javascript/squadbox/group_page.js
+++ b/http_handler/static/javascript/squadbox/group_page.js
@@ -1,5 +1,7 @@
 $(document).ready(function(){
 
+	$('[data-toggle="tooltip"]').tooltip();
+
 	var user_name = $.trim($('#user_email').text()),
 		group_name = $.trim($("#group-name").text()),
 		member = $.trim($(".member").text()) == "Member",
@@ -15,7 +17,9 @@ $(document).ready(function(){
 		btn_set_mod = $("#btn-set-mod"),
 		btn_add_list = $('#btn-add-list'),
 		action_select = $('#actionSelect'),
-		btn_delete_group = $("#btn-delete-group");
+		btn_delete_group = $("#btn-delete-group"),
+		activate_btn = $('#activate-btn');
+
 
 	var admin_buttons = [btn_add_members, btn_edit_group_info, btn_set_admin, btn_set_mod, 
 						btn_delete_members, btn_add_list, action_select, btn_delete_group];
@@ -35,7 +39,7 @@ $(document).ready(function(){
 
 	delete_group =
 	    function(params) {
-	    	warningMessage = "Are you sure? This will delete the squad including all emails ever sent within this squad in the archive."
+	    	warningMessage = "Are you sure? This will delete the squad and all stored emails associated with it."
 	        var confirmation = confirm(warningMessage);
 	        if (confirmation) {
 	        	$.post('/delete_group', params,
@@ -47,37 +51,23 @@ $(document).ready(function(){
 	        		});
 	        }
 	    }
-		
-	// activating and deactivating does nothing
 
-	// activate_group = 
-	// 	function(params){
-	// 		$.post('/activate_group', params, 
-	// 			function(res){
-	// 				if (res.status) {
-	// 					$(".group_active").text('True');
-	// 					group_active = true;
-	// 					fix_visibility();
-	// 				}
-	// 				notify(res, true);
-	// 			}
-	// 		);	
-	// 	};
-		
-	
-	// deactivate_group = 
-	// 	function(params){
-	// 		$.post('/deactivate_group', params, 
-	// 			function(res){
-	// 				if (res.status) {
-	// 					$(".group_active").text('False');
-	// 					group_active = false;
-	// 					fix_visibility();
-	// 				}
-	// 				notify(res, true);
-	// 			}
-	// 		);	
-	// 	};	
+	activate_btn.click(function() {
+
+
+		var params = {'group_name' : group_name},
+			post_to = ($(this)[0].innerHTML == 'Activate') ? '/activate_group' : '/deactivate_group';
+
+		$.post(post_to, params, function(res) {
+			notify(res, true);
+			if (res.status) {
+				setTimeout(function() {
+					window.location.reload();
+				}, 
+				400);
+			}
+		});
+	});
 
 	var post_edit_members = function(params) {
 		$.post('/edit_members', params, function(res){

--- a/http_handler/static/javascript/squadbox/rejected.js
+++ b/http_handler/static/javascript/squadbox/rejected.js
@@ -1,0 +1,23 @@
+$(document).ready(function() {
+
+	var delete_btn = $('#delete-btn'),
+		group_name = $('#group-name')[0].innerHTML;
+
+	delete_btn.click(function(){
+		if (confirm("Are you sure you want to delete the selected messages? This cannot be undone.")) {
+			var to_delete = [];
+			$("input:checkbox:checked").each(function(){
+				var val_str = $(this).val();
+				var [_, thread_id, post_id] = val_str.split('-');
+				to_delete.push(thread_id + '-' + post_id);
+			});
+
+			$.post('/delete_posts', {'id_pairs' : to_delete.join(',')}, 
+				function(res) {
+					if (res.status) window.location.href = "/groups/" + group_name + "/rejected";
+					notify(res, true);
+			});
+
+		}
+	})
+});

--- a/http_handler/static/javascript/squadbox/rejected_thread.js
+++ b/http_handler/static/javascript/squadbox/rejected_thread.js
@@ -2,22 +2,38 @@ $(document).ready(function() {
 	var message_link = $('#message-link'),
 		send_btn = $('#send-btn');
 		cancel_btn = $('#cancel-btn'),
+		delete_btn = $('#delete-btn'),
 		notify_link = $('#notify-link')[0],
 		message_form = $('#message-form')[0],
 		admin_msg = $('#admin-message')[0],
 		show_msg = $('#show-msg'),
-		post_text = $('#post-text')[0];
+		post_text = $('#post-text')[0],
+		post_id = $('#post-id')[0].innerHTML,
+		thread_id = $('#thread-id')[0].innerHTML,
+		group_name = $('#group-name')[0].innerHTML;
 
 	message_link.click(function() {
 		message_form.style.display = 'inline';
 		notify_link.style.display = 'none';
+		delete_btn[0].style.display = 'none';
 	});
 
 	cancel_btn.click(function() {
 		message_form.style.display = 'none';
 		notify_link.style.display = 'inline';
+		delete_btn[0].style.display = 'inline';
 	});
 
+	delete_btn.click(function() {
+		if (confirm("Are you sure you want to delete this message? This cannot be undone.")) {
+			$.post('delete_post', {'id' : post_id, 'thread_id' : thread_id}, 
+				function(res) {
+					if (res.status) window.location.href = "/groups/" + group_name + "/rejected";
+					notify(res, true);
+				}
+			);
+		} 
+	});
 
 	show_msg.click(function() {
 		if (post_text.style.display == 'none') {
@@ -25,7 +41,7 @@ $(document).ready(function() {
 			$('#show-msg')[0].innerHTML = 'Hide message text';
 		} else {
 			post_text.style.display = 'none';
-			$('#show-msg')[0].innerHTML = 'Show message text'
+			$('#show-msg')[0].innerHTML = 'Show message text';
 		}
 	});
 

--- a/http_handler/static/javascript/squadbox/rejected_thread.js
+++ b/http_handler/static/javascript/squadbox/rejected_thread.js
@@ -1,0 +1,35 @@
+$(document).ready(function() {
+	var message_link = $('#message-link'),
+		send_btn = $('#send-btn');
+		cancel_btn = $('#cancel-btn'),
+		notify_link = $('#notify-link')[0],
+		message_form = $('#message-form')[0],
+		admin_msg = $('#admin-message')[0],
+		show_msg = $('#show-msg'),
+		post_text = $('#post-text')[0];
+
+	message_link.click(function() {
+		message_form.style.display = 'inline';
+		notify_link.style.display = 'none';
+	});
+
+	cancel_btn.click(function() {
+		message_form.style.display = 'none';
+		notify_link.style.display = 'inline';
+	});
+
+
+	show_msg.click(function() {
+		if (post_text.style.display == 'none') {
+			post_text.style.display = 'inline';
+			$('#show-msg')[0].innerHTML = 'Hide message text';
+		} else {
+			post_text.style.display = 'none';
+			$('#show-msg')[0].innerHTML = 'Show message text'
+		}
+	});
+
+	// send_btn.click(function() {
+	// 	var params = {}
+	// });
+});

--- a/http_handler/static/javascript/squadbox/thread.js
+++ b/http_handler/static/javascript/squadbox/thread.js
@@ -60,6 +60,8 @@ $(document).ready(function() {
 
             } else notify(status_res, true);
 
+            console.log(status_res);
+
             if (status_res.status) setTimeout(function() {
                 window.location = '/dashboard';
             }, 1000);

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -174,6 +174,8 @@ elif WEBSITE == 'squadbox':
                     url(r'^reject_get', 'browser.views.reject_get'),
                     url(r'^approve_post', 'browser.views.approve_post'),
                     url(r'^reject_post', 'browser.views.reject_post'),
+                    url(r'^delete_posts', 'browser.views.delete_posts'),
+                    url(r'^delete_post', 'browser.views.delete_post'),
                     url(r'^blacklist_get', 'browser.views.blacklist_get'),
                     url(r'^whitelist_get', 'browser.views.whitelist_get'),
                     url(r'^whitelist', 'browser.views.whitelist'),

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -98,6 +98,9 @@ urlpatterns = patterns('',
     url(r'^accounts/', include('registration.backends.default.urls')),
 
     url(r'^subscribe/confirm/(?P<token>.+)$', 'browser.views.subscribe_confirm'),
+
+    url(r'^activate_group', 'browser.views.activate_group'),
+    url(r'^deactivate_group', 'browser.views.deactivate_group'),
     )
 
 # murmur-only patterns
@@ -111,8 +114,6 @@ if WEBSITE == 'murmur':
                     url(r'^group_list', 'browser.views.group_list'),
                     url(r'^groups/(?P<group_name>[\w-]+)/add_list', 'browser.views.add_list_view'),
                     url(r'^groups/(?P<group_name>[\w-]+)/create_post', 'browser.views.my_group_create_post_view'),
-                    url(r'^activate_group', 'browser.views.activate_group'),
-                    url(r'^deactivate_group', 'browser.views.deactivate_group'),
                     url(r'^my_groups', 'browser.views.my_groups'),
                     url(r'^list_my_groups', 'browser.views.list_my_groups'), 
 

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -178,6 +178,8 @@ elif WEBSITE == 'squadbox':
                     url(r'^whitelist_get', 'browser.views.whitelist_get'),
                     url(r'^whitelist', 'browser.views.whitelist'),
                     url(r'^blacklist', 'browser.views.blacklist'),
+                    url(r'^groups/(?P<group_name>[\w-]+)/rejected', 'browser.views.rejected'),
+                    url(r'^rejected_thread$', 'browser.views.rejected_thread'),
                     ]
 
     urlpatterns.extend(new_patterns)

--- a/schema/models.py
+++ b/schema/models.py
@@ -28,6 +28,9 @@ class Post(models.Model):
 	# fwds to this Murmur group
 	poster_email = models.EmailField(max_length=255, null=True)
 
+	# often "from" header is Firstname LastName <person@website.com>. if so, save that name.
+	poster_name = models.CharField(max_length=50, null=True)
+
 	# moderation-related data 
 
 	# what state a message is currently in 

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -365,8 +365,8 @@ def handle_post_murmur(message, group, host, verified):
 		if message_is_reply:
 			res = insert_reply(group.name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, verified, forwarding_list=original_list, sender_name=sender_name)
 		else:
-			res = insert_post(group.name, orig_message, msg_text['html'], user, sender_addr, msg_id, verified, attachments, forwarding_list=original_list, sender_name=sender_name)
-			
+			res = insert_post(group.name, orig_message, msg_text['html'], user, sender_addr, msg_id, verified, attachments=attachments, forwarding_list=original_list, sender_name=sender_name)
+
 		if not res['status']:
 			send_error_email(group.name, res['code'], sender_addr, ADMIN_EMAILS)
 			return

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -541,17 +541,17 @@ def handle_post_squadbox(message, group, host, verified):
 						disposition=attachment['disposition'],
 						id=attachment['id'])
 
-		if group.active:
+		if not group.active:
 			reason = 'deactivated'
 		elif status == 'A':
 			reason = 'whitelist'
 		elif status == 'R':
 			reason = 'blacklist'
 
-		html_blurb = unicode(html_ps_squadbox(group.name, sender_addr, reason))
+		html_blurb = unicode(ps_squadbox(sender_addr, reason, True))
 		mail.Html = get_new_body(msg_text, html_blurb, 'html')
 
-		plain_blurb = plain_ps_squadbox(group.name, sender_addr, reason)
+		plain_blurb = ps_squadbox(sender_addr, reason, False)
 		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
 
 		relay.deliver(mail, To = admin.email)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -285,7 +285,9 @@ def handle_post_murmur(message, group, host, verified):
 	to_emails = [i[1] for i in getaddresses(to_header)]
 
 	msg_text = get_body(email_message)
-	_, sender_addr = parseaddr(message['From'].lower())
+	sender_name, sender_addr = parseaddr(message['From'].lower())
+	if sender_name == '':
+		sender_name = None
 	attachments = get_attachments(email_message)
 
 	try:
@@ -361,9 +363,9 @@ def handle_post_murmur(message, group, host, verified):
 			original_list_email = original_list.email
 
 		if message_is_reply:
-			res = insert_reply(group.name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, verified, forwarding_list=original_list)
+			res = insert_reply(group.name, "Re: " + orig_message, msg_text['html'], user, sender_addr, msg_id, verified, forwarding_list=original_list, sender_name=sender_name)
 		else:
-			res = insert_post(group.name, orig_message, msg_text['html'], user, sender_addr, msg_id, verified, attachments, forwarding_list=original_list)
+			res = insert_post(group.name, orig_message, msg_text['html'], user, sender_addr, msg_id, verified, attachments, forwarding_list=original_list, sender_name=sender_name)
 			
 		if not res['status']:
 			send_error_email(group.name, res['code'], sender_addr, ADMIN_EMAILS)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -493,18 +493,23 @@ def handle_post_squadbox(message, group, host, verified):
 	# initially, assume that it's pending and will go through moderation. 
 	status = 'P'
 
-	# if whitelisted, accept; if blacklisted, reject 
-	white_or_blacklist = WhiteOrBlacklist.objects.filter(group=group, email=sender_addr)
-	if white_or_blacklist.exists():
-		w_or_b = white_or_blacklist[0]
-		if w_or_b.blacklist:
-			status = 'R' # if blacklist could means "gets moderated", need to change. 
-		elif w_or_b.whitelist:
-			status = 'A' # sender is whitelisted, so we can accept the mesasge 
+	if not group.active:
+		status = 'A'
+
+	else:
+		# if whitelisted, accept; if blacklisted, reject 
+		white_or_blacklist = WhiteOrBlacklist.objects.filter(group=group, email=sender_addr)
+		if white_or_blacklist.exists():
+			w_or_b = white_or_blacklist[0]
+			if w_or_b.blacklist:
+				status = 'R' # if blacklist could means "gets moderated", need to change. 
+			elif w_or_b.whitelist:
+				status = 'A' # sender is whitelisted, so we can accept the message 
 
 	# either:
 	# 1) sender is whitelisted
 	# 2) sender is blacklisted, but the user still wants rejected messages. 
+	# 3) moderation is turned off for now (inactive group)
 	if status == 'A' or (status == 'R' and group.send_rejected_tagged):
 		# we can just send it on to the intended recipient, i.e. the admin of the group. 
 		mg = MemberGroup.objects.get(group=group, admin=True)
@@ -536,7 +541,9 @@ def handle_post_squadbox(message, group, host, verified):
 						disposition=attachment['disposition'],
 						id=attachment['id'])
 
-		if status == 'A':
+		if group.active:
+			reason = 'deactivated'
+		elif status == 'A':
 			reason = 'whitelist'
 		elif status == 'R':
 			reason = 'blacklist'

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -365,11 +365,13 @@ def plain_forwarded_blurb(group_name, to_list, original_list_email=None):
 def html_ps_squadbox(squad_name, sender, reason):
 	content = ''
 	if reason == 'whitelist':
-		content = 'This message was automatically approved by Squadbox because the sender %s is on your whitelist.' % sender
+		content = 'This message was automatically approved because the sender %s is on your whitelist.' % sender
 	elif reason == 'blacklist':
-		content = 'This message was automatically rejected by Squadbox because the sender %s is on your blacklist.' % sender
+		content = 'This message was automatically rejected because the sender %s is on your blacklist.' % sender
 	elif reason.startswith('approved') or reason.startswith('rejected'):
 		content = 'This message was ' + reason 
+	elif reason == 'deactivated':
+		content = 'This message was automatically approved because your squad is disabled.'
 
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
 	return body
@@ -377,11 +379,13 @@ def html_ps_squadbox(squad_name, sender, reason):
 def plain_ps_squadbox(squadbox, sender, reason):
 	content = ''
 	if reason == 'whitelist':
-		content = 'This message was automatically approved by Squadbox because the sender %s is on your whitelist.' % sender
+		content = 'This message was automatically approved because the sender %s is on your whitelist.' % sender
 	elif reason == 'blacklist':
-		content = 'This message was automatically rejected by Squadbox because the sender %s is on your blacklist.' % sender
+		content = 'This message was automatically rejected because the sender %s is on your blacklist.' % sender
 	elif reason.startswith('approved') or reason.startswith('rejected'):
 		content = 'This message was ' + reason 
+	elif reason == 'deactivated':
+		content = 'This message was automatically approved because your squad is disabled.'
 
 	body = '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
 	return body

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -362,8 +362,9 @@ def plain_forwarded_blurb(group_name, to_list, original_list_email=None):
 	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
 	return body
 
-def html_ps_squadbox(squad_name, sender, reason):
-	content = ''
+
+def ps_squadbox(sender, reason, HTML):
+
 	if reason == 'whitelist':
 		content = 'This message was automatically approved because the sender %s is on your whitelist.' % sender
 	elif reason == 'blacklist':
@@ -372,23 +373,13 @@ def html_ps_squadbox(squad_name, sender, reason):
 		content = 'This message was ' + reason 
 	elif reason == 'deactivated':
 		content = 'This message was automatically approved because your squad is disabled.'
+	else:
+		content = ''
 
-	body = '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
-	return body
-
-def plain_ps_squadbox(squadbox, sender, reason):
-	content = ''
-	if reason == 'whitelist':
-		content = 'This message was automatically approved because the sender %s is on your whitelist.' % sender
-	elif reason == 'blacklist':
-		content = 'This message was automatically rejected because the sender %s is on your blacklist.' % sender
-	elif reason.startswith('approved') or reason.startswith('rejected'):
-		content = 'This message was ' + reason 
-	elif reason == 'deactivated':
-		content = 'This message was automatically approved because your squad is disabled.'
-
-	body = '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
-	return body
+	if HTML:
+		return '%s%s%s' % (HTML_SUBHEAD, content, HTML_SUBTAIL)
+	else:
+		return '%s%s%s' % (PLAIN_SUBHEAD, content, PLAIN_SUBTAIL)
 
 def html_ps(group, thread, post_id, membergroup, following, muting, tag_following, tag_muting, tags, original_list_email=None):
 	#follow_addr = 'mailto:%s' %(group_name + '+' + FOLLOW_SUFFIX + '@' + HOST)


### PR DESCRIPTION
you'll want to look at my other PR first, as this branch has those changes merged in. 

this PR adds support for deactivating your squad. there's a button on the website to turn it off, and now when handling incoming emails in smtp_handler, we check if the squad is active. if it isn't, we just auto-approve the message and send it on with a footer "this message was automatically approved because you squad is deactivated". 