### PR TITLE
encode as utf-8 for subjects with non-ascii chars

### DIFF
--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -852,7 +852,7 @@ def help(message, address=None, host=None):
 @stateless
 def send_account_info(message, address=None, host=None):
 
-	subj_string = str(message['Subject']).lower()
+	subj_string = message['Subject'].encode('utf-8').lower()
 	activation_str = ("account activation on %s" % WEBSITE).lower()
 	reset_str = ("password reset on %s" % WEBSITE).lower()
 


### PR DESCRIPTION
very small fix - str() assumes all ASCII characters so throws an error when the subject line has something non-ASCII in it. If you explicitly tell it to encode as utf-8, then no error. 