### PR TITLE
Threadhash

### DIFF
--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -14,7 +14,7 @@
 		</input>
 		<br><br>
 		<span class="strong">{{ group_or_squad | title }} Description:</span> <br>
-		<span class="italic-med">Maximum 140 characters</span><br>
+		<span class="italic-med">(optional) Maximum 140 characters</span><br>
 		<textarea id="edit-group-description" maxlength="140">{{group_info.description.strip }}</textarea>
 		<br><br>
 		{% if website == "murmur" %}
@@ -94,6 +94,13 @@
 			<input type="checkbox" id="mod-edit-wl-bl">
 			{% endif %}
 			Allow squad moderators to add and remove senders from your whitelist and blacklist
+			<br>
+			{% if group_info.auto_approve_after_first %}
+			<input type="checkbox" id="auto-approve" checked>
+			{% else %}
+			<input type="checkbox" id="auto-approve">
+			{% endif %}
+			After a sender's first post to a thread is approved, auto-approve their future posts to the thread
 		{% endif %}
 		<br><br>
 		<button type="button" id="btn-save-settings"">Save Changes</button>

--- a/browser/templates/squadbox/moderate_user_thread.html
+++ b/browser/templates/squadbox/moderate_user_thread.html
@@ -1,0 +1,24 @@
+{% extends "group_container_base.html" %}
+
+{% block container-content %}
+	
+	{% if res.status %}
+	You've turned moderation <span class="strong">{{ type }}</span> for the sender {{ sender }} in thread "{{ subject }}".
+
+	{% if type == 'on' %}
+		All future emails from this sender to this thread will undergo moderation. 
+		<br><br>
+		To turn moderation off for {{ sender }}'s future emails to "{{ subject }}",  
+		<a href="/moderate_user_for_thread_get?group_name={{group_name}}&sender={{sender}}&subject={{subject}}&moderate=off">click here</a>.
+	{% else %}
+		All future emails from this sender to this thread will be automatically approved. 
+		<br><br>
+		To turn moderation back on for {{ sender }}'s future emails to "{{ subject }}", 
+		<a href="/moderate_user_for_thread_get?group_name={{group_name}}&sender={{sender}}&subject={{subject}}&moderate=on">click here</a>.
+	{% endif %}
+
+	{% else %}
+		Sorry, there was an error: {{ res.code | lower }}.
+	{% endif %}
+
+{% endblock %}

--- a/browser/views.py
+++ b/browser/views.py
@@ -519,7 +519,8 @@ def edit_group_info(request):
 		send_rejected = request.POST['send_rejected_tagged'] == 'true'
 		store_rejected = request.POST['store_rejected'] == 'true'
 		mod_edit = request.POST['mod_edit'] == 'true'
-		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, user) 
+		auto_approve = request.POST['auto_approve'] == 'true'
+		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, auto_approve, user) 
 		if res['status']:
 			active_group = request.session.get('active_group')
 			if active_group == old_group_name:

--- a/browser/views.py
+++ b/browser/views.py
@@ -1605,3 +1605,25 @@ def rejected(request, group_name):
 		#return HttpResponse(json.dumps(to_return), content_type="application/json")
 	else:
 		return redirect(global_settings.LOGIN_URL)
+
+
+@render_to("squadbox/moderate_user_thread.html")
+@login_required
+def moderate_user_for_thread_get(request):
+	if request.user.is_authenticated():
+		user = get_object_or_404(UserProfile, email=request.user.email)
+		group_name = request.GET.get('group_name')
+		subject = request.GET.get('subject')
+		sender = request.GET.get('sender')
+		on_off = (request.GET.get('moderate') == 'on')
+		res = engine.main.adjust_moderate_user_for_thread(user, group_name, sender, subject, on_off)
+
+		groups = Group.objects.filter(membergroup__member=user).values("name")
+		active_group = Group.objects.get(name=group_name)
+		role = get_role_from_group_name(user, group_name)
+		
+		return {'res' : res, 'website' : WEBSITE, 'group_name' : group_name, 'user' : user,
+				'type' : request.GET.get('moderate'), 'sender' : sender, 'subject' : subject,
+				'active_group' : active_group, 'active_group_role' : role}
+	else:
+		return redirect(global_settings.LOGIN_URL + '?next=/approve_get?group_name=%s&post_id=%s' % (group_name, post_id))

--- a/engine/main.py
+++ b/engine/main.py
@@ -1008,9 +1008,14 @@ def insert_post_web(group_name, subject, message_text, user):
 def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, verified, attachments=None, forwarding_list=None, post_status=None, sender_name=None):
 	res = {'status' : False}
 	thread = None
+
+	logging.debug("ATTACHMENTS:")
+	logging.debug(attachments)
 	try:
 		group = Group.objects.get(name=group_name)
-		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, verified, attachments, forwarding_list=forwarding_list, post_status=post_status, sender_name=sender_name)
+		logging.debug("here1")
+		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, verified, attachments=attachments, forwarding_list=forwarding_list, post_status=post_status, sender_name=sender_name)
+		logging.debug("here2")
 		res['status'] = True
 		res['post_id'] = p.id
 		res['msg_id'] = p.msg_id
@@ -1023,12 +1028,14 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, ve
 	except Group.DoesNotExist:
 		res['code'] = msg_code['GROUP_NOT_FOUND_ERROR']
 
-	except Exception, e:
-		logging.debug(e)
-		if(thread and thread.id):
-			thread.delete()
-		res['code'] = msg_code['UNKNOWN_ERROR']
+	# except Exception, e:
+	# 	logging.debug("here10")
+	# 	logging.debug(e)
+	# 	if(thread and thread.id):
+	# 		thread.delete()
+	# 	res['code'] = msg_code['UNKNOWN_ERROR']
 
+	logging.debug("here3")
 	logging.debug(res)
 	return res
 
@@ -1524,7 +1531,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				if new_status == 'A':
 					reason = 'approved by moderator %s.' % user.email
 					if not check_if_sender_moderated_for_thread(g, p.poster_email, p.subject):
-						hashed = get_sender_subject_hash(sender_addr, subject)
+						hashed = get_sender_subject_hash(p.poster_email, p.subject)
 						ThreadHash.objects.get_or_create(sender_subject_hash=hashed, group=g, moderate=False)
 
 				elif new_status == 'R':

--- a/engine/main.py
+++ b/engine/main.py
@@ -1525,8 +1525,9 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				if new_status == 'A':
 					reason = 'approved by moderator %s.' % user.email
 					if not check_if_sender_moderated_for_thread(g.name, p.poster_email, p.subject):
-						hashed = get_sender_subject_hash(p.poster_email, p.subject)
-						ThreadHash.objects.get_or_create(sender_subject_hash=hashed, group=g, moderate=False)
+						if g.auto_approve_after_first:
+							hashed = get_sender_subject_hash(p.poster_email, p.subject)
+							ThreadHash.objects.get_or_create(sender_subject_hash=hashed, group=g, moderate=False)
 
 				elif new_status == 'R':
 					reason = 'rejected by moderator %s.' % user.email

--- a/engine/main.py
+++ b/engine/main.py
@@ -1426,7 +1426,6 @@ def unmute_tag(tag_name, group_name, user=None, email=None):
 def update_blacklist_whitelist(user, group_name, emails, whitelist, blacklist):
 	res = {'status' : False}
 
-
 	# illegal to have both set to true
 	if whitelist and blacklist:
 		res['code'] = msg_code['REQUEST_ERROR']
@@ -1498,7 +1497,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 
 			group_tag_names = [t.tag.name for t in TagThread.objects.filter(thread=p.thread)]
 
-			if tags is not None and len(tags) > 0:
+			if tags and len(tags) > 0:
 				tag_names = tags.split(',')
 				for t in tag_names:
 					if t not in group_tag_names:
@@ -1516,7 +1515,6 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 			# or if it was rejected but the recipient wants rejected emails with tag
 			if new_status == 'A' or (new_status == 'R' and g.send_rejected_tagged):
 
-
 				mgs = MemberGroup.objects.filter(group=g, admin=True)
 				if not mgs.exists():
 					return res
@@ -1525,6 +1523,10 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 
 				if new_status == 'A':
 					reason = 'approved by moderator %s.' % user.email
+					if not check_if_sender_moderated_for_thread(g, p.poster_email, p.subject):
+						hashed = get_sender_subject_hash(sender_addr, subject)
+						ThreadHash.objects.get_or_create(sender_subject_hash=hashed, group=g, moderate=False)
+
 				elif new_status == 'R':
 					reason = 'rejected by moderator %s.' % user.email
 

--- a/engine/main.py
+++ b/engine/main.py
@@ -1009,13 +1009,9 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, ve
 	res = {'status' : False}
 	thread = None
 
-	logging.debug("ATTACHMENTS:")
-	logging.debug(attachments)
 	try:
 		group = Group.objects.get(name=group_name)
-		logging.debug("here1")
 		p, thread, recipients, tags, tag_objs = _create_post(group, subject, message_text, user, sender_addr, msg_id, verified, attachments=attachments, forwarding_list=forwarding_list, post_status=post_status, sender_name=sender_name)
-		logging.debug("here2")
 		res['status'] = True
 		res['post_id'] = p.id
 		res['msg_id'] = p.msg_id
@@ -1028,14 +1024,12 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, ve
 	except Group.DoesNotExist:
 		res['code'] = msg_code['GROUP_NOT_FOUND_ERROR']
 
-	# except Exception, e:
-	# 	logging.debug("here10")
-	# 	logging.debug(e)
-	# 	if(thread and thread.id):
-	# 		thread.delete()
-	# 	res['code'] = msg_code['UNKNOWN_ERROR']
+	except Exception, e:
+		logging.debug(e)
+		if(thread and thread.id):
+			thread.delete()
+		res['code'] = msg_code['UNKNOWN_ERROR']
 
-	logging.debug("here3")
 	logging.debug(res)
 	return res
 

--- a/engine/main.py
+++ b/engine/main.py
@@ -1523,14 +1523,14 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 					admin = mgs[0].member
 
 				if new_status == 'A':
-					reason = 'approved by moderator %s.' % user.email
+					reason = 'moderator approved'
 					if not check_if_sender_moderated_for_thread(g.name, p.poster_email, p.subject):
 						if g.auto_approve_after_first:
 							hashed = get_sender_subject_hash(p.poster_email, p.subject)
 							ThreadHash.objects.get_or_create(sender_subject_hash=hashed, group=g, moderate=False)
 
 				elif new_status == 'R':
-					reason = 'rejected by moderator %s.' % user.email
+					reason = 'moderator rejected'
 
 				tags = [t.tag.name for t in TagThread.objects.filter(thread = p.thread)]
 
@@ -1547,8 +1547,12 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				for a in attachments:
 					mail.attach(filename=a['name'], data=a['data'])
 
-				html_blurb = unicode(ps_squadbox(p.poster_email, reason, True))
-				plain_blurb = ps_squadbox(p.poster_email, reason, False)
+				orig_subj = p.subject
+				if orig_subj.startswith('Re: '):
+					orig_subj = orig_subj[4:]		
+
+				html_blurb = unicode(ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, True))
+				plain_blurb = ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, False)
 
 				html_prefix = ''
 				if new_status == 'R' and len(p.mod_explanation) > 0:

--- a/engine/main.py
+++ b/engine/main.py
@@ -265,7 +265,7 @@ def create_group(group_name, group_desc, public, attach, send_rejected, store_re
 	logging.debug(res)
 	return res
 
-def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, user):
+def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, auto_approve, user):
 	res = {'status':False}	
 	try:
 		group = Group.objects.get(name=old_group_name)
@@ -277,6 +277,7 @@ def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, 
 		group.send_rejected_tagged = send_rejected
 		group.show_rejected_site = store_rejected
 		group.mod_edit_wl_bl = mod_edit
+		group.auto_approve_after_first = auto_approve
 		group.save()
 		res['status'] = True	
 	except Group.DoesNotExist:

--- a/http_handler/static/javascript/edit_group_info.js
+++ b/http_handler/static/javascript/edit_group_info.js
@@ -25,6 +25,7 @@ $(document).ready(function() {
             params.send_rejected_tagged = $('#send-rejected')[0].checked;
             params.store_rejected = $('#store-rejected')[0].checked;
             params.mod_edit = $('#mod-edit-wl-bl')[0].checked;
+            params.auto_approve = $('#auto-approve')[0].checked;
         } else if (website == "murmur") {
             params.public = $('input[name=pubpriv]:checked', '#group-info-form').val();
 
@@ -32,6 +33,8 @@ $(document).ready(function() {
             params.send_rejected_tagged = true;
             params.store_rejected = true;
             params.mod_edit = true;
+            params.auto_approve = false;
+
         }
 
         $.post('/edit_group_info', params,

--- a/http_handler/static/javascript/squadbox/thread.js
+++ b/http_handler/static/javascript/squadbox/thread.js
@@ -63,7 +63,7 @@ $(document).ready(function() {
             console.log(status_res);
 
             if (status_res.status) setTimeout(function() {
-                window.location = '/dashboard';
+                window.location = '/mod_queue/' + group_name;
             }, 1000);
         });
     });

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -193,6 +193,8 @@ elif WEBSITE == 'squadbox':
 
                     url(r'^groups/(?P<group_name>[\w-]+)/rejected', 'browser.views.rejected'),
                     url(r'^rejected_thread$', 'browser.views.rejected_thread'),
+
+                    url(r'^moderate_user_for_thread_get', 'browser.views.moderate_user_for_thread_get'),
                     ]
 
     urlpatterns.extend(new_patterns)

--- a/schema/models.py
+++ b/schema/models.py
@@ -156,6 +156,7 @@ class MemberGroup(models.Model):
 	always_follow_thread = models.BooleanField(default=True)
 	upvote_emails = models.BooleanField(default=True)
 	receive_attachments = models.BooleanField(default=True)
+	last_emailed = models.DateTimeField(null=True)
 	
 	def __unicode__(self):
 		return '%s - %s' % (self.member.email, self.group.name)

--- a/schema/models.py
+++ b/schema/models.py
@@ -204,6 +204,10 @@ class Group(models.Model):
 	# whether moderators can edit whitelist and blacklist 
  	mod_edit_wl_bl = models.BooleanField(default=True) 
 
+ 	# whether to automatically approve emails from a sender to a thread 
+ 	# in this group after their first post to the thread is approved
+ 	auto_approve_after_first = models.BooleanField(default=False)
+
 	
 	def __unicode__(self):
 		return self.name

--- a/schema/models.py
+++ b/schema/models.py
@@ -95,7 +95,15 @@ moderation.
 '''
 class ThreadHash(models.Model):
 	group = models.ForeignKey('Group')
+
+	# we store a hash so that we don't keep information about
+	# this thread once all its posts are approved.
 	sender_subject_hash = models.CharField(max_length=40)
+
+	# if this is True, the group's admin has opted in to keep
+	# moderation on for the user's posts to this thread. if it's 
+	# False (but this object exists), this user previously posted 
+	# and the post was approved. 
 	moderate = models.BooleanField(default=False)
 		
 class Tag(models.Model):

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -509,11 +509,11 @@ def handle_post_squadbox(message, group, host, verified):
 
 				# case 1 
 				if group.auto_approve_after_first:
-					reason = 'already approved'
+					reason = 'auto approve on'
 					logging.debug('Sender approved for this thread previously; automatically approving post')
 				# case 2
 				else:
-					reason = 'moderation turned off for sender'
+					reason = "mod off for sender-thread"
 					
 			else:
 				logging.debug('Post needs to be moderated')
@@ -569,10 +569,11 @@ def handle_post_squadbox(message, group, host, verified):
 			mail['Cc'] = ','.join(ccs)
 
 		add_attachments(mail, attachments)
-		html_blurb = unicode(ps_squadbox(sender_addr, reason, group.name, subj, True))
+
+		html_blurb = unicode(ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, True))
 		mail.Html = get_new_body(msg_text, html_blurb, 'html')
 
-		plain_blurb = ps_squadbox(sender_addr, reason, group.name, subj, False)
+		plain_blurb = ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, False)
 		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
 
 		relay.deliver(mail, To = admin.email)

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -497,7 +497,7 @@ def handle_post_squadbox(message, group, host, verified):
 		# if whitelisted, accept; if blacklisted, reject 
 		status, reason = check_whitelist_blacklist(group, sender_addr)
 		if not reason:
-			if check_if_sender_approved_for_thread(group, sender_addr, original_subj):
+			if check_if_sender_approved_for_thread(group.name, sender_addr, original_subj):
 				status = 'A'
 				reason = 'already approved'
 				logging.debug('Sender approved for this thread previously; automatically approving post')
@@ -550,11 +550,10 @@ def handle_post_squadbox(message, group, host, verified):
 			mail['Cc'] = ','.join(ccs)
 
 		add_attachments(mail, attachments)
-
-		html_blurb = unicode(ps_squadbox(sender_addr, reason, True))
+		html_blurb = unicode(ps_squadbox(sender_addr, reason, group.name, subj, True))
 		mail.Html = get_new_body(msg_text, html_blurb, 'html')
 
-		plain_blurb = ps_squadbox(sender_addr, reason, False)
+		plain_blurb = ps_squadbox(sender_addr, reason, group.name, subj, False)
 		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
 
 		relay.deliver(mail, To = admin.email)

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -106,7 +106,7 @@ def setup_post(From, Subject, group_name):
 
 def setup_moderation_post(group_name):
 
-	subject = 'New post to Squadbox squad %s requires approval' % group_name 
+	subject = 'New posts to Squadbox squad %s require approval' % group_name 
 	to = '%s Moderators <%s+mods@%s>' % (group_name, group_name, HOST)
 	from_addr = 'Squadbox Notifications <%s+notifications@%s>' % (group_name, HOST)
 
@@ -119,8 +119,11 @@ def setup_moderation_post(group_name):
 		"Precedence": 'list'
 		})
 
-	plain_body = "To view all pending posts to the squad, visit your dashboard: %s/dashboard" % BASE_URL
-	html_body = "To view all pending posts to the squad, visit your <a href='%s/dashboard'>dashboard</a>." % BASE_URL 
+	pending_count = Post.objects.filter(group__name=group_name, status='P').count()
+
+	body_base = 'As of now, there are %s pending posts. To view all of them, visit the ' %  pending_count
+	plain_body = body_base + "moderation queue: %s/mod_queue/%s" % (BASE_URL, group_name)
+	html_body = body_base + "<a href='%s/mod_queue/%s'>moderation queue</a>." % (BASE_URL, group_name)
 
 	blurb = "You're receiving this message because you're a moderator of the squad %s." % group_name
 	html_ps_blurb = '%s%s%s' % (HTML_SUBHEAD, blurb, HTML_SUBTAIL)
@@ -342,21 +345,21 @@ def plain_forwarded_blurb(group_name, to_list, original_list_email=None):
 
 def ps_squadbox(sender, reason, HTML):
 
-	content = 'This message was automatically '
+	content = 'This message was '
 
 	if reason == 'whitelist':
-		content += 'rejected because the sender %s is on your whitelist.' % sender
+		content += 'automatically rejected because the sender %s is on your whitelist.' % sender
 	elif reason == 'blacklist':
-		content += 'rejected because the sender %s is on your blacklist.' % sender
+		content += 'automatically rejected because the sender %s is on your blacklist.' % sender
 	elif reason.startswith('approved') or reason.startswith('rejected'):
 		content += reason
 	elif reason == 'deactivated':
-		content += 'approved because your squad is disabled.'
+		content += 'automatically approved because your squad is disabled.'
 	elif reason == 'already approved':
-		content += 'approved because a previous post from %s to this thread was approved.' % sender 
+		content += 'automatically approved because a previous post from %s to this thread was approved.' % sender 
 		#+ ' If you want to turn moderation back on for posts from %s, '
 	elif reason == 'no mods':
-		content += 'approved because your squad has no moderators.'
+		content += 'automatically approved because your squad has no moderators.'
 	else:
 		content = ''
 

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -108,8 +108,8 @@ MOD_ON = {
 }
 
 MOD_BACK_ON = {
-	True: "<br><br>To turn it back on, follow <a href='%s'>this link</a>.",
-	False: "\n\nTo turn it back on, follow this link: <%s>."
+	True: " To turn it back on, follow <a href='%s'>this link</a>.",
+	False: " To turn it back on, follow this link: <%s>."
 }
 
 


### PR DESCRIPTION
uses code from the other PR i have open, so merge that one first (might be conflicts, lmk)

**you'll need to do an auto migration**

**changes**:
- frontend/backend for changing the auto-approve setting
- endpoints to click from email signature that turn moderation on/off for a sender+thread pair
- threadhash logic, if auto-approve setting is on: 
    - we store a hash of sender|subject along with foreign key to the related group and a boolean indicating whether the owner has specifically opted in to continue moderation for this user
    - when we get a post from a user, we see if threadhash for them exists
        - if it does and moderate=True, post needs moderation (user opted in)
        - if it does and moderate=False, auto-approve post (this is not their first post, and first one was approved) 
        - if it doesn't, then post goes through moderation and (if approved) threadhash will be created and stored upon approval 
- better logic for emailing mods
    - when we get a new email find the least recently emailed moderator, and if we haven't emailed them in last 24 hrs, send them a notification and update last emailed time 
    - todo: should probably have cron job or similar that resends the notification after 24 hrs if the emails haven't been dealt with yet
- if a squad has no moderators, then automatically approve emails received, and send to owner with a link to add mods 
- reworked wording/links in email footers
