### PR TITLE
spot for entering moderation rules/preferences

### DIFF
--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -4,8 +4,7 @@
 	<h3>Edit {{ group_or_squad | title }} Information and Settings</h3>
 	<hr/>
 	<form id="group-info-form">
-		<span class="strong">{{ group_or_squad | title }} Name:</span>
-		<br>
+		<h4 class="strong">{{ group_or_squad | title }} Name:</h4>
 		<span class="italic-med">
 			Maximum 20 characters. Only alphanumeric characters, underscores, and dashes allowed.
 		</span>
@@ -13,13 +12,12 @@
 		<input id="edit-group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;" value="{{group_info.name}}">
 		</input>
 		<br><br>
-		<span class="strong">{{ group_or_squad | title }} Description:</span> <br>
+		<h4 class="strong">{{ group_or_squad | title }} Description:</h4>
 		<span class="italic-med">Maximum 140 characters</span><br>
 		<textarea id="edit-group-description" maxlength="140">{{group_info.description.strip }}</textarea>
 		<br><br>
 		{% if website == "murmur" %}
-			<span class="strong">Privacy Settings:</span>
-			<br>
+			<h4 class="strong">Privacy Settings:</h4>
 			{% if group_info.public %}
 				<input type="radio" name="pubpriv" value="public" id="rdo-pub-create-group" checked>
 			{% else %}
@@ -39,7 +37,7 @@
 			<span class="italic-small">Only users added to this group by admins will be notified about the group.</span>
 			<br>
 		{% endif %}
-		<span class="strong">Attachment Policy: </span> <br>
+		<h4 class="strong">Attachment Policy: </h4>
 		{% if group_info.allow_attachments %}
 			<input type="radio" name="attach" value="yes-attach" id="rdo-attach-create-group" checked>
 		{% else %}
@@ -71,7 +69,7 @@
 		
 		{% if website == "squadbox" %}
 			<br>
-			<span class="strong">Rejected Messages: </span> <br>
+			<h4 class="strong">Rejected Messages: </h4>
 			{% if group_info.send_rejected_tagged %}
 			<input type="checkbox" id="send-rejected" checked> 
 			{% else %}
@@ -87,7 +85,12 @@
 			Store rejected messages on the Squadbox website</input>
 			<span class="italic-small">We will store messages that your moderators reject, and display a link to view them on your homepage.</span>
 			<br>
-			<span class="strong">Moderation:</span> <br>
+			<h4 class="strong">Moderation:</h4>
+			<span class="strong">Policy/rules:</span> <br>
+			<span class="italic-med">Any information you want moderators to know regarding your preferences</span><br>
+			<textarea id="edit-mod-rules">{{group_info.mod_rules.strip }}</textarea>
+			<br>
+			<span class="strong">Options:</span> <br>
 			{% if group_info.mod_edit_wl_bl %}
 			<input type="checkbox" id="mod-edit-wl-bl" checked>
 			{% else %}

--- a/browser/templates/edit_group_info.html
+++ b/browser/templates/edit_group_info.html
@@ -87,8 +87,8 @@
 			<span class="italic-small">We will store messages that your moderators reject, and display a link to view them on your homepage.</span>
 			<br>
 			<h4 class="strong">Moderation:</h4>
-			<span class="strong">Policy/rules:</span> <br>
-			<span class="italic-med">Any information you want moderators to know regarding your preferences</span><br>
+			<span class="italic-medium">Please enter any information you want moderators to know regarding your preferences. For example, "please reject messages with profanity."
+			</span><br>
 			<textarea id="edit-mod-rules">{{group_info.mod_rules.strip }}</textarea>
 			<br>
 			<span class="strong">Options:</span> <br>

--- a/browser/templates/squadbox/group_page.html
+++ b/browser/templates/squadbox/group_page.html
@@ -3,83 +3,91 @@
 	<link href="/static/css/third-party/datatable.css" rel="stylesheet">
 {% endblock %}
 {% block content %}
-	<span id='mod-can-edit' style='display:none'>{{ group_info.group.mod_edit_wl_bl }}</span>
-	<div class="container">
-		<div class="group-container">
-			
-			{% if group_info.admin %}
-				<span class="admin label">owner</span>
-				{% elif group_info.moderator %}
-				<span class="mod label">mod</span>
-			{% endif %}
-			
-			<h3><span id="group-name">{{ group_info.group.name }}</span></h3>
-			<hr>
-			{% if group_info.group.description == "" %}
-				<span class="italic-med">No description</span>
+<span id='mod-can-edit' style='display:none'>{{ group_info.group.mod_edit_wl_bl }}</span>
+<div class="container">
+	<div class="group-container">
+		
+		{% if group_info.admin %}
+			<span class="admin label">owner</span>
+		{% elif group_info.moderator %}
+			<span class="mod label">mod</span>
+		{% endif %}
+		
+		<h3><span id="group-name">{{ group_info.group.name }}</span></h3>
+
+		<hr>
+
+		{% if group_info.group.description == "" %}
+			<span class="italic-med">No description</span>
+		{% else %}
+			<span class="italic-med">{{ group_info.group.description }}</span>
+		{% endif %}
+		
+		{% if group_info.admin %}
+
+			<br><br>
+			{% if group_info.active %}
+				<button id='activate-btn'>Deactivate</button> <span data-toggle="tooltip" title="When your squad is deactivated, emails will be automatically approved. You can reactivate your squad at any time.">&#9432;</span>
+				<br><br>
+				Your squad is currently <span class="strong">active</span>.
 			{% else %}
-				<span class="italic-med">{{ group_info.group.description }}</span>
+				<button id='activate-btn'>Activate</button> <span data-toggle="tooltip" title="When your squad is active, emails that aren't from a whitelisted or blacklisted sender will go through moderation before they're sent to you.">&#9432;</span>
+				<br><br>
+				Your squad is currently <span class="strong">deactivated</span>.
+			{% endif %}
+
+			<br>
+			{% if group_info.group.allow_attachments %}
+				Attachments <span class="strong">are allowed</span>.
+			{% else %}
+				<span class="strong">No Attachments</span> are allowed.
+			{% endif %}
+
+			<br>
+
+			{% if group_info.group.send_rejected_tagged %}
+				Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
+			{% else %}
+				Rejected messages <span class="strong">will not</span> be sent to your inbox.
+			{% endif %}
+
+			<br>
+
+			{% if group_info.group.show_rejected_site %}
+				Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
+			{% else %}
+				Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
+			{% endif %}
+			<br><br>
+
+		{% endif %}
+		
+		<div id="group-options">
+			{% if group_info.subscribed %}
+				{% if group_info.admin %}
+					<button type="button" id="btn-edit-group-info">Edit settings</button>
+				{% endif %}
+				<br><br>
+			{% else %}
+				<button type="button" id="btn-edit-settings" style="display: none;"></button>
 			{% endif %}
 			
-			{% if group_info.admin %}
-				<br><br>
-				{% if group_info.active %}
-					<button id='activate-btn'>Deactivate</button> <span data-toggle="tooltip" title="When your squad is deactivated, emails will be automatically approved. You can reactivate your squad at any time.">&#9432;</span>
-				{% else %}
-					<button id='activate-btn'>Activate</button> <span data-toggle="tooltip" title="When your squad is active, emails that aren't from a whitelisted or blacklisted sender will go through moderation before they're sent to you.">&#9432;</span>
-				{% endif %}
-				<br><br>
-				{% if group_info.active %}
-					Your squad is currently <span class="strong">active</span>.
-				{% else %}
-					Your squad is currently <span class="strong">deactivated</span>.
-				{% endif %}
-				<br>
-				{% if not group_info.group.allow_attachments %}
-					<span class="strong">No Attachments</span> are allowed.
-				{% else %}
-					Attachments <span class="strong">are allowed</span>.
-				{% endif %}
-				<br>
-				{% if not group_info.group.send_rejected_tagged %}
-					Rejected messages <span class="strong">will not</span> be sent to your inbox.
-				{% else %}
-					Rejected messages <span class="strong">will</span> be sent to your inbox with a [rejected] tag.
-				{% endif %}
-				<br>
-				{% if not group_info.group.show_rejected_site %}
-					Rejected messages <span class="strong">will not</span> be stored or displayed on this site.
-				{% else %}
-					Rejected messages <span class="strong">will</span> be stored and displayed to you on this site.
-				{% endif %}
-				<br><br>
+			{% if group_info.subscribed and not group_info.admin %}
+				<button type="button" id="btn-unsubscribe-group">Leave squad</button>
 			{% endif %}
-			
-			<div id="group-options">
-				{% if group_info.subscribed %}
-					{% if group_info.admin %}
-						<button type="button" id="btn-edit-group-info">Edit settings</button>
-					{% endif %}
-					<br><br>
-				{% else %}
-					<button type="button" id="btn-edit-settings" style="display: none;">Edit My Settings</button>
-				{% endif %}
-				
-				{% if group_info.subscribed and not group_info.admin %}
-					<button type="button" id="btn-unsubscribe-group">Leave squad</button>
-				{% endif %}
-			</div>
-			
+		</div>
+		
+		<hr>
+		<h3>Moderation Rules</h3>
+		<p>{{ group_info.group.mod_rules }}</p>
+
+		{% if group_info.admin %}
 			<hr>
 			<h3>Squad Members</h3>
-			{% if group_info.admin %}
-				<button type="button" id="btn-add-members">Invite new moderators</button>
-				<button type="button" id="btn-del-members">Remove selected</button>
-			{% else %}
-				<button type="button" id="btn-add-members" style="display: none;">Add Members</button>
-			{% endif %}
+			<button type="button" id="btn-add-members">Invite new moderators</button>
+			<button type="button" id="btn-del-members">Remove selected</button>
 			
-			{% if group_info.admin or group_info.moderator %}
+
 			<table id="members-table" class="display" cellspacing="0" width="100%">
 				<thead>
 					<tr>
@@ -94,21 +102,39 @@
 						{% endif %}
 					</tr>
 				</thead>
-			
-			
+				
 				<tbody>
-				{% for member in group_info.members %}
-					
-					{% if member.email == user.email %}
-						<tr class="my_row">
+					{% for member in group_info.members %}
+						{% if member.email == user.email %}
+							<tr class="my_row">
 						{% else %}
 							<tr>
-							{% endif %}
-							
-							{% if group_info.admin %}
-								<td><input class="checkbox checkbox-user" type="checkbox" id ={{ member.id }}></td>
-							{% endif %}
-							<td>{{ member.email }}</td>
+						{% endif %}
+								
+						{% if group_info.admin %}
+							<td><input class="checkbox checkbox-user" type="checkbox" id ={{ member.id }}></td>
+						{% endif %}
+
+						<td>{{ member.email }}</td>
+						{% if flavour != "mobile" %}
+							<td>{{ member.joined }}</td>
+							<th>
+								{% if member.admin %}
+									<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+								{% endif %}
+							</th>
+							<th>
+								{% if member.mod %}
+									<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+								{% endif %}
+							</th>
+						{% endif %}
+					{% endfor %}
+
+					{% for member in group_info.members_pending %}
+						<tr>
+							<td></td>
+							<td><i>{{ member.email }} (pending)</i></td>
 							{% if flavour != "mobile" %}
 								<td>{{ member.joined }}</td>
 								<th>
@@ -122,44 +148,22 @@
 									{% endif %}
 								</th>
 							{% endif %}
-						{% endfor %}
-						{% for member in group_info.members_pending %}
-							<tr>
-								<td></td>
-								<td><i>{{ member.email }} (pending)</i></td>
-								{% if flavour != "mobile" %}
-									<td>{{ member.joined }}</td>
-									<th>
-										{% if member.admin %}
-											<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-										{% endif %}
-									</th>
-									<th>
-										{% if member.mod %}
-											<span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-										{% endif %}
-									</th>
-								{% endif %}
-							</tr>
-						{% endfor %}
-					</tbody>
-				</table>
-				<br>
-				<hr>
-						
+						</tr>
+					{% endfor %}
+				</tbody>
+			</table>
+			<br>
+					
+			<hr>
 			<h3>Whitelist</h3>
 			<p>The whitelist is for trusted senders. Emails from them will be automatically approved.</p>
-			{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
-				<button type="button" id="btn-add-whitelist">Add more addresses</button>
-				<button type="button" id="btn-del-whitelist">Remove selected</button>
-			{% else %}
-				<button type="button" id="btn-add-whitelist" style='display: none'></button>
-				<button type="button" id="btn-del-whitelist" style='display: none'></button>
-			{% endif %}
+			<button type="button" id="btn-add-whitelist">Add more addresses</button>
+			<button type="button" id="btn-del-whitelist">Remove selected</button>
+			
 			<table id="whitelist-table" class="display" cellspacing="0" width="100%">
 				<thead>
 					<tr>
-						{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
+						{% if group_info.admin %}
 							<th>Select</th>
 						{% endif %}
 						<th>Email</th>
@@ -172,7 +176,7 @@
 				<tbody>
 					{% for w in group_info.whitelist %}
 						<tr>
-							{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
+							{% if group_info.admin %}
 								<td><input class="checkbox checkbox-whitelist" type="checkbox" id ={{ w.email }}></td>
 							{% endif %}
 							<td>{{ w.email }}</td>
@@ -186,36 +190,27 @@
 			<br><br>
 			<a href='/gmail_setup?group={{group_info.group.name}}'>Setup automatic forwarding and import Gmail contacts to this squad's whitelist &raquo;</a>
 
+
 			<hr>
 			<h3>Blacklist</h3>
 			<p>The blacklist is for known harassers. Emails from them will be automatically rejected.</p>
-			{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
-				<button type="button" id="btn-add-blacklist">Add more addresses</button>
-				<button type="button" id="btn-del-blacklist">Remove selected</button>
-			{% else %}
-				<button type="button" id="btn-add-blacklist" style='display:none;'></button>
-				<button type="button" id="btn-del-blacklist" style='display:none'></button>
-			{% endif %}
-
+			<button type="button" id="btn-add-blacklist">Add more addresses</button>
+			<button type="button" id="btn-del-blacklist">Remove selected</button>
 			<table id="blacklist-table" class="display" cellspacing="0" width="100%">
 				<thead>
 					<tr>
-						{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
-							<th>Select</th>
-						{% endif %}
+						<th>Select</th>
 						<th>Email</th>
 						{% if flavour != "mobile" %}
 							<th>Added</th>
 						{% endif %}
 					</tr>
 				</thead>
-				
+						
 				<tbody>
 					{% for b in group_info.blacklist %}
 						<tr>
-							{% if group_info.admin or group_info.moderator and group_info.group.mod_edit_wl_bl %}
-								<td><input class="checkbox checkbox-blacklist" type="checkbox" id ={{ b.email }}></td>
-							{% endif %}
+							<td><input class="checkbox checkbox-blacklist" type="checkbox" id ={{ b.email }}></td>
 							<td>{{ b.email }}</td>
 							{% if flavour != "mobile" %}
 								<td>{{ b.timestamp }}</td>
@@ -224,15 +219,13 @@
 					{% endfor %}
 				</tbody>
 			</table>
-			{% if group_info.admin %}
-				<hr>
-				<div style="text-align:center">
-					<button type="button" class="btn btn-danger" id="btn-delete-group">Delete squad</button>
-				</div>
-			{% endif %}
+			<hr>
+			<div style="text-align:center">
+				<button type="button" class="btn btn-danger" id="btn-delete-group">Delete squad</button>
+			</div>
 		{% endif %}
-		</div>
 	</div>
+</div>
 {% endblock %}
 {% block customjs %}
 	<script type="text/javascript" src="/static/javascript/notify.js"></script>

--- a/browser/templates/squadbox/moderation_modal.html
+++ b/browser/templates/squadbox/moderation_modal.html
@@ -1,0 +1,16 @@
+<div class="modal fade" id="mod-rules-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title" id="myModalLabel">Moderation Preferences</h4>
+      </div>
+      <div class="modal-body">
+      {{ modal_data }}
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -1,6 +1,7 @@
 {% extends "group_container_base.html" %}
 
 {% block container-content %}
+{% include "squadbox/moderation_modal.html" %}
 	<div class="main-area-content">
 	<div hidden id='group-name'>{{ active_group.name }} </div>
 	<div hidden id='post-id'>{{ thread.post.id }}</div>
@@ -40,10 +41,11 @@
 		{% endif %}
 		<BR>
 	</div>
-	<br>
 
 	<div class='text-center' style='text-align:center;'>
-	
+	<br>
+	<a href="" data-toggle="modal" data-target="#mod-rules-modal"><i>review squad owner's preferences</i></a><br><br>
+
 	<label class="radio-inline"><input type="radio" id="approve-radio" name="approve-reject" value="approve">Approve</label>
 	<label class="radio-inline"><input type="radio" id="reject-radio" name="approve-reject" value="reject">Reject</label>
 	<br><br>

--- a/browser/util.py
+++ b/browser/util.py
@@ -7,8 +7,6 @@ from bs4 import BeautifulSoup
 
 from schema.models import MemberGroup, Attachment
 
-from schema.models import MemberGroup
-
 ALLOWED_TAGS = [
     'a',
     'abbr',

--- a/browser/views.py
+++ b/browser/views.py
@@ -517,7 +517,8 @@ def edit_group_info(request):
 		send_rejected = request.POST['send_rejected_tagged'] == 'true'
 		store_rejected = request.POST['store_rejected'] == 'true'
 		mod_edit = request.POST['mod_edit'] == 'true'
-		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, user) 
+		mod_rules = request.POST['mod_rules']
+		res = engine.main.edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, mod_rules, user) 
 		if res['status']:
 			active_group = request.session.get('active_group')
 			if active_group == old_group_name:

--- a/browser/views.py
+++ b/browser/views.py
@@ -235,6 +235,12 @@ def thread(request):
 		
 		member_group = MemberGroup.objects.filter(member=user, group=group)
 		is_member = member_group.exists()
+
+
+		if is_member and (member_group[0].moderator or membergroup_[0].admin):
+			modal_data = group.mod_rules
+		else:
+			modal_data = None
 		
 		active_group = load_groups(request, groups, user, group_name=group.name)
 		if group.public or is_member:
@@ -252,7 +258,7 @@ def thread(request):
 				thread_to = admin.member.email
 			return {'user': request.user, 'groups': groups, 'thread': res, 'thread_to' : thread_to, 
 					'post_id': post_id, 'active_group': active_group, 'website' : WEBSITE, 
-					'active_group_role' : role, 'groups_links' : groups_links}
+					'active_group_role' : role, 'groups_links' : groups_links, 'modal_data' : modal_data}
 		else:
 			if active_group['active']:
 				request.session['active_group'] = None

--- a/engine/main.py
+++ b/engine/main.py
@@ -266,7 +266,7 @@ def create_group(group_name, group_desc, public, attach, send_rejected, store_re
 	logging.debug(res)
 	return res
 
-def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, user):
+def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit, mod_rules, user):
 	res = {'status':False}	
 	try:
 		group = Group.objects.get(name=old_group_name)
@@ -278,6 +278,7 @@ def edit_group_info(old_group_name, new_group_name, group_desc, public, attach, 
 		group.send_rejected_tagged = send_rejected
 		group.show_rejected_site = store_rejected
 		group.mod_edit_wl_bl = mod_edit
+		group.mod_rules = mod_rules
 		group.save()
 		res['status'] = True	
 	except Group.DoesNotExist:

--- a/http_handler/static/javascript/edit_group_info.js
+++ b/http_handler/static/javascript/edit_group_info.js
@@ -25,6 +25,7 @@ $(document).ready(function() {
             params.send_rejected_tagged = $('#send-rejected')[0].checked;
             params.store_rejected = $('#store-rejected')[0].checked;
             params.mod_edit = $('#mod-edit-wl-bl')[0].checked;
+            params.mod_rules = $("#edit-mod-rules").val();
         } else if (website == "murmur") {
             params.public = $('input[name=pubpriv]:checked', '#group-info-form').val();
 
@@ -32,6 +33,7 @@ $(document).ready(function() {
             params.send_rejected_tagged = true;
             params.store_rejected = true;
             params.mod_edit = true;
+            params.mod_rules = '';
         }
 
         $.post('/edit_group_info', params,

--- a/schema/models.py
+++ b/schema/models.py
@@ -183,6 +183,8 @@ class Group(models.Model):
 	send_rejected_tagged = models.BooleanField(default=True)
 	# whether moderators can edit whitelist and blacklist 
 	mod_edit_wl_bl = models.BooleanField(default=True) 
+	# description of policy/rules for moderation
+	mod_rules = models.TextField(null=True)
 	
 	def __unicode__(self):
 		return self.name


### PR DESCRIPTION
I merged in the code from the other outstanding PR already, so hopefully won't be conflicts.

what's new here - a way for squad owners to enter prefs for their moderators. **you will need to do an auto migration for adding this**. later on we'll probably want to build this out and make it more complex, allow them to add formatting, have some suggested categories they can check off (for ex. profanity), etc. 

so I've added
1) a new field in the squad settings page where this info will be added/edited
2) that data is now displayed on the squad info page
3) on the page for a moderator reviewing a particular post, they can click a link that pops up a modal displaying the rules. I'm not sure if this is the best way to do that (mods might want to be able to view post and rules side-by-side) but it's functional anyway. 

and somewhat related I updated the engine.main.group_info_page function to only return the data a particular user is allowed to see (before, regardless of user role, we would send everything in HTTP response. unsafe) 