### PR TITLE
Store original messages on S3 

### DIFF
--- a/browser/util.py
+++ b/browser/util.py
@@ -7,8 +7,6 @@ from bs4 import BeautifulSoup
 
 from schema.models import MemberGroup, Attachment
 
-from schema.models import MemberGroup
-
 ALLOWED_TAGS = [
     'a',
     'abbr',

--- a/browser/views.py
+++ b/browser/views.py
@@ -1540,7 +1540,7 @@ def serve_attachment(request, hash_filename):
 
 			if MemberGroup.objects.filter(member=user, group=group).exists():
 				s3 = S3Connection(AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, is_secure=True)
-				filepath = 'attachments/%s/%s' % (hash_filename, attachment.true_filename)
+				filepath = '%s/attachments/%s/%s' % (WEBSITE, hash_filename, attachment.true_filename)
 				temporary_auth_url = s3.generate_url(60, 'GET', bucket=AWS_STORAGE_BUCKET_NAME, key=filepath)
 				return HttpResponseRedirect(temporary_auth_url)
 			else:

--- a/engine/main.py
+++ b/engine/main.py
@@ -8,7 +8,7 @@ from lamson.mail import MailResponse
 from smtp_handler.utils import *
 from bleach import clean
 from cgi import escape
-from attachments import upload_attachments, download_attachments
+from s3_storage import upload_attachments, download_attachments
 import re
 import hashlib
 import random

--- a/engine/main.py
+++ b/engine/main.py
@@ -1,24 +1,20 @@
-import sys, logging, base64, email#, datetime
-from schema.models import *
-from constants import *
-from django.utils.timezone import utc
-from django.db.models import Q
-from browser.util import *
-from lamson.mail import MailResponse
-from smtp_handler.utils import *
+import base64, email, hashlib, json, logging, random, re, sys
+
 from bleach import clean
 from cgi import escape
-from s3_storage import upload_attachments, download_attachments
-import re
-import hashlib
-import random
+from django.utils.timezone import utc
+from django.db.models import Q
 from email.utils import parseaddr
 from html2text import html2text
+from lamson.mail import MailResponse
 
-from http_handler.settings import BASE_URL, WEBSITE, AWS_STORAGE_BUCKET_NAME
-import json
+from browser.util import *
+from constants import *
 from engine.constants import extract_hash_tags, ALLOWED_MESSAGE_STATUSES
-
+from http_handler.settings import BASE_URL, WEBSITE, AWS_STORAGE_BUCKET_NAME
+from s3_storage import upload_attachments, download_attachments, download_message
+from schema.models import *
+from smtp_handler.utils import *
 
 def list_groups(user=None):
 	groups = []
@@ -1021,7 +1017,6 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, ve
 		res['tag_objs'] = tag_objs
 		res['recipients'] = recipients
 		res['verified'] = verified
-		res['timestamp'] = p.timestamp
 
 	except Group.DoesNotExist:
 		res['code'] = msg_code['GROUP_NOT_FOUND_ERROR']
@@ -1045,7 +1040,6 @@ def insert_squadbox_reply(group_name, subject, message_text, user, sender_addr, 
 		post.save()
 		upload_attachments(attachments, msg_id)
 		res['status'] = True
-		res['post'] = post
 
 	except Group.DoesNotExist:
 		res['code'] = msg_code['GROUP_NOT_FOUND_ERROR']
@@ -1138,7 +1132,6 @@ def insert_reply(group_name, subject, message_text, user, sender_addr, msg_id, v
 			res['thread_id'] = thread.id
 			res['msg_id'] = msg_id
 			res['post_id'] = r.id
-			res['timestamp'] = r.timestamp
 
 		else:
 			res['code'] = msg_code['NOT_MEMBER']
@@ -1511,6 +1504,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				_create_tag(g, p.thread, 'rejected')
 
 			p.save()
+
 			res['status'] = True
 			res['post_id'] = post_id
 			res['new_status'] = new_status
@@ -1545,6 +1539,15 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 
 				mail = MailResponse(From = p.poster_email, To = admin.email, Subject = new_subj)
 				mail['message-id'] = p.msg_id
+
+				res = download_message(p.id, p.msg_id)
+				if not res['status']:
+					logging.debug("Error downloading original message")
+				else:
+					original_msg = email.message_from_string(res['message'])
+					mail['In-Reply-To'] = original_msg['In-Reply-To']
+					mail['References'] = original_msg['References']
+					mail['Cc'] = original_msg['Cc']
 
 				attachments = download_attachments(p.msg_id)
 				for a in attachments:

--- a/engine/main.py
+++ b/engine/main.py
@@ -1039,6 +1039,7 @@ def insert_squadbox_reply(group_name, subject, message_text, user, sender_addr, 
 		post = Post(author=user, subject=subject, msg_id=msg_id, post=message_text, group=group, thread=thread, verified_sender=verified, poster_email=sender_addr, poster_name=sender_name, status=post_status)
 		post.save()
 		upload_attachments(attachments, msg_id)
+		res['post_id'] = post.id
 		res['status'] = True
 
 	except Group.DoesNotExist:

--- a/engine/main.py
+++ b/engine/main.py
@@ -1021,6 +1021,7 @@ def insert_post(group_name, subject, message_text, user, sender_addr, msg_id, ve
 		res['tag_objs'] = tag_objs
 		res['recipients'] = recipients
 		res['verified'] = verified
+		res['timestamp'] = p.timestamp
 
 	except Group.DoesNotExist:
 		res['code'] = msg_code['GROUP_NOT_FOUND_ERROR']
@@ -1137,6 +1138,7 @@ def insert_reply(group_name, subject, message_text, user, sender_addr, msg_id, v
 			res['thread_id'] = thread.id
 			res['msg_id'] = msg_id
 			res['post_id'] = r.id
+			res['timestamp'] = r.timestamp
 
 		else:
 			res['code'] = msg_code['NOT_MEMBER']

--- a/engine/s3_storage.py
+++ b/engine/s3_storage.py
@@ -2,6 +2,7 @@ import hashlib, logging, random, time
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 
+from http_handler.settings import WEBSITE
 from schema.models import Attachment
 
 def upload_attachments(attachments, msg_id):
@@ -19,7 +20,7 @@ def upload_attachments(attachments, msg_id):
             hash_filename = hashlib.sha1(filename + salt + thetime).hexdigest()
             hash_collision = Attachment.objects.filter(hash_filename=hash_filename).exists()
 
-        path = 'attachments/%s/%s' % (hash_filename, filename)
+        path = '%s/attachments/%s/%s' % (WEBSITE, hash_filename, filename)
         with default_storage.open(path, 'wb+') as destination:
             destination.write(attachment_file)
 
@@ -33,7 +34,7 @@ def download_attachments(msg_id):
     files = []
     attachments = Attachment.objects.filter(msg_id=msg_id)
     for a in attachments:
-        path = 'attachments/%s/%s' % (a.hash_filename, a.true_filename)
+        path = '%s/attachments/%s/%s' % (WEBSITE, a.hash_filename, a.true_filename)
         with default_storage.open(path, 'r') as f:
             file = {
                 'name' : a.true_filename,
@@ -45,7 +46,7 @@ def download_attachments(msg_id):
 def upload_message(message, post_id, post_timestamp):
 
     res = {'status' : False}
-    path = 'original_messages/%s_%s' % (post_id, post_timestamp.strftime('%s'))
+    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, post_timestamp.strftime('%s'))
 
     try: 
         message_string = str(message)
@@ -61,7 +62,7 @@ def upload_message(message, post_id, post_timestamp):
 def download_message(post_id, post_timestamp):
 
     res = {'status' : False}
-    path = 'original_messages/%s_%s' % (post_id, post_timestamp.strftime('%s'))
+    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, post_timestamp.strftime('%s'))
 
     # try:
     with default_storage.open(path, 'r') as f:

--- a/engine/s3_storage.py
+++ b/engine/s3_storage.py
@@ -43,10 +43,10 @@ def download_attachments(msg_id):
             files.append(file)
     return files
 
-def upload_message(message, post_id, post_timestamp):
+def upload_message(message, post_id, msg_id):
 
     res = {'status' : False}
-    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, post_timestamp.strftime('%s'))
+    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, msg_id)
 
     try: 
         message_string = str(message)
@@ -59,10 +59,10 @@ def upload_message(message, post_id, post_timestamp):
 
     return res
 
-def download_message(post_id, post_timestamp):
+def download_message(post_id, msg_id):
 
     res = {'status' : False}
-    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, post_timestamp.strftime('%s'))
+    path = '%s/original_messages/%s_%s' % (WEBSITE, post_id, msg_id)
 
     # try:
     with default_storage.open(path, 'r') as f:

--- a/engine/s3_storage.py
+++ b/engine/s3_storage.py
@@ -42,10 +42,10 @@ def download_attachments(msg_id):
             files.append(file)
     return files
 
-def upload_message(message, post_id):
+def upload_message(message, post_id, post_timestamp):
 
     res = {'status' : False}
-    path = 'original_messages/%s' % post_id
+    path = 'original_messages/%s_%s' % (post_id, post_timestamp.strftime('%s'))
 
     try: 
         message_string = str(message)
@@ -58,19 +58,19 @@ def upload_message(message, post_id):
 
     return res
 
-def download_message(post_id):
+def download_message(post_id, post_timestamp):
 
     res = {'status' : False}
-    path = 'original_messages/%s' % post_id
+    path = 'original_messages/%s_%s' % (post_id, post_timestamp.strftime('%s'))
 
-    try:
-        with default_storage.open(path, 'r') as f:
-            message = f.read()
+    # try:
+    with default_storage.open(path, 'r') as f:
+        message = f.read()
 
-        res['message'] = message
-        res['status'] = True
+    res['message'] = message
+    res['status'] = True
 
-    except Exception, e:
-        logging.debug("Error downloading original message: %s" % e)
+    # except Exception, e:
+    #     logging.debug("Error downloading original message: %s" % e)
 
     return res

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -457,8 +457,6 @@ def handle_post_murmur(message, group, host, verified):
 def handle_post_squadbox(message, group, host, verified):
 
 	email_message = message_from_string(str(message))
-	logging.debug("MESSAGE STRING:")
-	logging.debug(str(message))
 	msg_id = message['Message-ID']
 
 	sender_name, sender_addr = parseaddr(message['From'].lower())
@@ -528,6 +526,10 @@ def handle_post_squadbox(message, group, host, verified):
 		status = 'A'
 		reason = 'no mods'
 		logging.debug("Squad has no moderators")
+	elif moderators.filter(member__email=sender_addr).exists():
+		status = 'A'
+		reason = 'is mod'
+		logging.debug('Message is from a moderator')
 
 	# if pending or rejected, we need to put it in the DB 
 	if status in ['P', 'R']:
@@ -546,9 +548,8 @@ def handle_post_squadbox(message, group, host, verified):
 			return
 
 		post_id = res['post_id']
-		post_time = res['timestamp']
 
-		res = upload_message(message, post_id, post_time)
+		res = upload_message(message, post_id, msg_id)
 		if not res['status']:
 			logging.debug("Error uploading original post to s3; continuing anyway")
 

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -559,7 +559,7 @@ def handle_post_squadbox(message, group, host, verified):
 	# 4) this group doesn't have any moderators yet
 	# 4) group has "auto approve after first post" on, and this sender posted before and got approved 
 	# (and the recipient did not subsequently opt back in to moderation for that user)
-	# 5) group has "auto approve after first post" off, but sender manually shut off moderation for this sender
+	# 5) group has "auto approve after first post" off, but owner manually shut off moderation for this sender
 	if status == 'A' or (status == 'R' and group.send_rejected_tagged):
 
 		# we can just send it on to the intended recipient, i.e. the admin of the group. 
@@ -572,8 +572,6 @@ def handle_post_squadbox(message, group, host, verified):
 		mail = MurmurMailResponse(From = message['From'], To = admin.email, Subject = new_subj)
 
 		fix_headers(message, mail)
-
-		mail['Sender'] = '%s@%s' % (group.name, HOST)
 
 		ccs = email_message.get_all('cc', None)
 		if ccs:

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -356,6 +356,12 @@ def handle_post_murmur(message, group, host, verified):
 			send_error_email(group.name, res['code'], sender_addr, ADMIN_EMAILS)
 			return
 
+		post_id = res['post_id']
+
+		res = upload_message(message, post_id, msg_id)
+		if not res['status']:
+			logging.debug("Error uploading original post to s3; continuing anyway")
+
 		subject = get_subject(message, res, group.name)
 		mail = setup_post(message['From'], subject,	group.name)
 

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -686,13 +686,24 @@ def check_if_can_post_murmur(group, sender_addr, possible_list_addresses):
 	return {'can_post' : False, 'reason' : 'not_member'}
 
 def fix_headers(message, mail):
-	if 'references' in message:
-			mail['References'] = message['references']
-	elif 'message-id' in message:
-		mail['References'] = message['message-id']	
+	if 'References' in message:
+			mail['References'] = message['References']
 
-	if 'in-reply-to' not in message:
-		mail["In-Reply-To"] = message['message-id']
+	# a message's own ID shouldn't show up in its references. commenting out for now.
+	# elif 'message-id' in message:
+	# 	mail['References'] = message['message-id']	
+
+	# a message can't be in reply to itself. if it's a reply to a previous message and needs 
+	# this header, then that value is contained in the received message's in-reply-to. so
+	# we should just copy it over if it exists, and that's it. commenting out for now. 
+
+	# if 'in-reply-to' not in message:
+	# 	mail["In-Reply-To"] = message['message-id']
+
+	if 'in-reply-to' in message:
+		mail['In-Reply-To'] = message['In-Reply-To']
+
+	mail['Message-ID'] = message['Message-ID']
 
 def add_attachments(mail, attachments):
 	for attachment in attachments:

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -91,6 +91,7 @@ SQUADBOX_REASONS = {
 						to this thread was approved.", 
 	'mod off for sender-thread' : "This message was auto-approved because you've turned moderation off \
 							for posts by %s to this thread.", 
+	'is mod' : "This message was auto-approved because it's from one of your moderators.",
 
 }
 
@@ -424,7 +425,7 @@ def ps_squadbox(sender, reason, squad_name, squad_auto_approve, subject, mod_ema
 	elif reason == 'moderator rejected':
 		content %= mod_email 
 
-	elif reason == 'no mods':
+	elif reason in ['no mods', 'is mod']:
 		content += EDIT_WL_BL_MODS[HTML] % squad_link
 
 	elif reason == 'mod off for sender-thread':


### PR DESCRIPTION
I branched this off from prev PR w/ threadhash, so probably easier for you if you merge that first. 

**changes here:**
- Cleaned up logic in serve_attachment, added better error handling 
- Store full original messages in text form on S3 under [WEBSITE]/original_messages/[post id]_[msg_id]. This happens for all Murmur posts, and for Squadbox posts that get stored in DB (those that aren't auto approved.) todo: delete posts from S3 once post is approved? 
- Download the original messages from S3 to get some more header data (in-reply-to, references) before sending out approved posts.
- Fix some header stuff on all posts - In-Reply-To should be the message-id of a separate message that this is a reply to. and References should contain message-ids of all past messages this message was replying to. 
- Reorganized how files are stored on S3. break down by Murmur/Squadbox, and then what they are (attachments or original_messages). **Note**: in order to not break links to attachments for existing Murmur production posts, any folder X in top-level directory for S3 bucket murmur-squadbox will need to be moved to murmur/attachments/X. (if you let me know when you are going to merge, I can do this.) 
- auto approve messages from moderators to the squad owner. (basically treat mods as part of whitelist.) 
