### PR TITLE
Multiple pending in thread

### DIFF
--- a/browser/templates/squadbox/mod_queue.html
+++ b/browser/templates/squadbox/mod_queue.html
@@ -9,27 +9,26 @@
 					You are not in any squads yet. <a href="/create_new_group">Create a new squad.</a>
 					{% elif mod_group_count == 0 %}
 					You aren't a moderator for any squads yet.
-					{% elif pending_posts|length == 0 %}
+					{% elif pending_threads|length == 0 %}
 					There are no pending emails for this squad.
 				{% else %}
 					<i>Click on an email to view its full text, and approve or reject it.</i><br><br>
 				{% endif %}
 				<ul id="post-list-table">
-					{% for post in pending_posts %}
-						<a href="/thread?group_name={{ post.to }}&tid={{ post.thread_id }}&post_id={{post.id}}">
-							<li class="row-item" id="{{ post.thread_id }}">
+					{% for thread in pending_threads %}
+						<a href="/thread?group_name={{ active_group }}&tid={{ thread.id }}">
+							<li class="row-item" id="{{ thread.id }}">
 									<div class="row">
-										<div class="col-md-3">
-											<span class="strong">
-												{% if post.from_name %}
-													{{ post.from_name }}
-												{% else %}
-													{{ post.from }}
-												{% endif %}
-											</span>
+										<div class="col-md-3 truncated-senders">
+											{% if thread.num_posts > 1 %}
+												<span class='unread'>
+												{{thread.num_posts }}
+												</span>
+											{% endif %}
+											{{ thread.senders }}
 										</div>
-										<div class="col-md-5"><div class="truncate"><span class="strong">{{ post.subject }}</span> - <span class="faded-message">{{ post.text }}</span></div></div>
-										<div class="col-md-4"><div class="pull-right" style="padding-right: 20px;">{{ post.timestamp|date:"n/j/y" }} at {{ post.timestamp|date:"h:i A" }}</div></div>
+										<div class="col-md-6"><div class="truncated-post"><span class="strong">{{ thread.subject }}</span> - <span class="faded-message">{{ thread.first_text }}</span></div></div>
+										<div class="col-md-3"><div class="pull-right" style="padding-right: 20px;">{{ thread.first_timestamp|date:"n/j/y" }} at {{ thread.first_timestamp|date:"h:i A" }}</div></div>
 									</div>
 							</li>
 						</a>

--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -40,7 +40,9 @@
 			</span>
 		{% endif %}
 		<BR>
+
 	</div>
+
 
 	<div class='text-center' style='text-align:center;'>
 	<br>
@@ -89,6 +91,26 @@
 	<br>
 	<button type="button" id="btn-submit">Submit</button>
 	</div>
+	<br>
+
+	<h4><span class='strong'>Other pending posts in this thread</span></h4>
+	<span class='italic-med'>(we'll have you moderate them next)</span>
+	<br><br>
+	{% for reply in thread.replies %}
+	<div class="reply">
+		<div class="main-area-content">
+			<span class="strong">{{ reply.from }}</span> on {{ reply.timestamp }}
+			{% if reply.attachments %}
+				| Attachments:
+				{% for name, url in reply.attachments %}
+					<a href="{{url}}">{{name}}</a>
+				{% endfor %}
+			{% endif %}
+			<br>
+			{% autoescape off %}{{ reply.text }}{% endautoescape %}				
+		</div>
+	</div>
+{% endfor %}
 
 {% endblock %}
 

--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -93,24 +93,26 @@
 	</div>
 	<br>
 
-	<h4><span class='strong'>Other pending posts in this thread</span></h4>
-	<span class='italic-med'>(we'll have you moderate them next)</span>
-	<br><br>
-	{% for reply in thread.replies %}
-	<div class="reply">
-		<div class="main-area-content">
-			<span class="strong">{{ reply.from }}</span> on {{ reply.timestamp }}
-			{% if reply.attachments %}
-				| Attachments:
-				{% for name, url in reply.attachments %}
-					<a href="{{url}}">{{name}}</a>
-				{% endfor %}
-			{% endif %}
-			<br>
-			{% autoescape off %}{{ reply.text }}{% endautoescape %}				
-		</div>
-	</div>
-{% endfor %}
+	{% if thread.replies %}
+		<h4><span class='strong'>Other pending posts in this thread</span></h4>
+		<span class='italic-med'>(we'll have you moderate them next)</span>
+		<br><br>
+		{% for reply in thread.replies %}
+			<div class="reply">
+				<div class="main-area-content">
+					<span class="strong">{{ reply.from }}</span> on {{ reply.timestamp }}
+					{% if reply.attachments %}
+						| Attachments:
+						{% for name, url in reply.attachments %}
+							<a href="{{url}}">{{name}}</a>
+						{% endfor %}
+					{% endif %}
+					<br>
+					{% autoescape off %}{{ reply.text }}{% endautoescape %}				
+				</div>
+			</div>
+		{% endfor %}
+	{% endif %}
 
 {% endblock %}
 

--- a/browser/views.py
+++ b/browser/views.py
@@ -1591,8 +1591,6 @@ def mod_queue(request, group_name):
 		curr_group = mg.group
 		role = get_role_from_group_name(user, group_name)
 
-		print "role:", role
-
 		return {'user' : request.user, 'groups' : groups, 'active_group' : curr_group, 'active_group_role' : role,
 				'groups_links' : groups_links, 'pending_threads' : res['threads'], 'website' : WEBSITE}
 	else:

--- a/browser/views.py
+++ b/browser/views.py
@@ -237,7 +237,7 @@ def thread(request):
 		is_member = member_group.exists()
 
 
-		if is_member and (member_group[0].moderator or membergroup_[0].admin):
+		if is_member and (member_group[0].moderator or member_group[0].admin):
 			modal_data = group.mod_rules
 		else:
 			modal_data = None
@@ -1583,13 +1583,8 @@ def mod_queue(request, group_name):
 
 		res = engine.main.load_pending_posts(user, group_name)
 
-		pending_posts = []
 		if not res['status']:
 			redirect('/404')
-		else:
-			for p in res['posts']:
-				p['text'] = html2text(p['text'])
-				pending_posts.append(p)
 
 		groups = Group.objects.filter(membergroup__member=user).values("name")
 		groups_links = get_groups_links_from_roles(user, groups)
@@ -1599,7 +1594,7 @@ def mod_queue(request, group_name):
 		print "role:", role
 
 		return {'user' : request.user, 'groups' : groups, 'active_group' : curr_group, 'active_group_role' : role,
-				'groups_links' : groups_links, 'pending_posts' : pending_posts, 'website' : WEBSITE}
+				'groups_links' : groups_links, 'pending_threads' : res['threads'], 'website' : WEBSITE}
 	else:
 		return redirect(global_settings.LOGIN_URL)
 

--- a/engine/main.py
+++ b/engine/main.py
@@ -746,6 +746,7 @@ def list_posts(group_name=None, user=None, timestamp_str=None, return_replies=Tr
 	return res
 	
 def load_thread(t, user=None, member=None):
+
 	following = False
 	muting = False
 	no_emails = False
@@ -764,8 +765,10 @@ def load_thread(t, user=None, member=None):
 		posts = Post.objects.filter(thread = t)	
 	elif WEBSITE == 'squadbox':
 		posts = Post.objects.filter(thread = t, status='P')
+
 	replies = []
 	post = None
+	
 	for p in posts:
 		post_likes = p.upvote_set.count()
 		total_likes += post_likes
@@ -796,10 +799,21 @@ def load_thread(t, user=None, member=None):
 					}
 		if p.forwarding_list:
 			post_dict['forwarding_list'] = p.forwarding_list.email
-		if not p.reply_to_id:
-			post = post_dict
-		else:
-			replies.append(post_dict)
+
+		if WEBSITE == 'murmur':
+			if not p.reply_to_id:
+				post = post_dict
+			else:
+				replies.append(post_dict)
+
+		elif WEBSITE == 'squadbox':
+			if post is None:
+				post = post_dict
+			elif post['timestamp'] > post_dict['timestamp']:
+				post = post_dict
+			else:
+				replies.append(post_dict)
+
 	tags = list(Tag.objects.filter(tagthread__thread=t).values('name', 'color'))
 	
 	return {'status': True,

--- a/http_handler/static/css/squadbox/base.css
+++ b/http_handler/static/css/squadbox/base.css
@@ -13,8 +13,16 @@ title {
 }
 
 
-.truncate {
-  width: 440px;
+.truncated-senders {
+  max-width: 200px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+
+.truncated-post {
+  max-width: 440px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -414,10 +422,11 @@ textarea {
 
 .unread{
 	background-color: #D7ECFA;
-        color: #3D7AA6;
+    color: #3D7AA6;
 	text-align:center;
 	width: 20px;
 	display: inline-block;
+	margin-right: 5px;
 }
 .default-text-active { 
 	color: #000000; 

--- a/http_handler/static/javascript/squadbox/thread.js
+++ b/http_handler/static/javascript/squadbox/thread.js
@@ -63,7 +63,11 @@ $(document).ready(function() {
             console.log(status_res);
 
             if (status_res.status) setTimeout(function() {
-                window.location = '/mod_queue/' + group_name;
+                if ($('.reply').length > 0) {
+                    location.reload(true);
+                } else {
+                    window.location = '/mod_queue/' + group_name;
+                }
             }, 1000);
         });
     });

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -275,7 +275,8 @@ def handle_post_murmur(message, group, host, verified):
 
 	to_header = email_message.get_all('to', [])
 	to_emails = [i[1] for i in getaddresses(to_header)]
-	sender_name, sender_addr = parseaddr(message['From'].lower())
+	sender_name, sender_addr = parseaddr(message['From'])
+	sender_addr = sender_addr.lower()
 	if not sender_name:
 		sender_name = None
 
@@ -465,7 +466,8 @@ def handle_post_squadbox(message, group, host, verified):
 	email_message = message_from_string(str(message))
 	msg_id = message['Message-ID']
 
-	sender_name, sender_addr = parseaddr(message['From'].lower())
+	sender_name, sender_addr = parseaddr(message['From'])
+	sender_addr = sender_addr.lower()
 	if sender_name == '':
 		sender_name = None
 	


### PR DESCRIPTION
again, needed code from previous PRs to do this, so this includes their code.

I was testing earlier and realized there was some weird behavior when multiple posts from the same thread were pending moderation. basically a link to the thread would show up multiple times in the queue, but would always only feature the first post to th thread. 

so this groups together pending posts by their thread, and indicates in the moderation queue that it is a multi-post thread. when a mod clicks on it, it will display all of them, and have them go one by one through all the thread's posts in order of time to approve/reject them. 
since the approve/reject page is the "thread" view from murmur, this required making a couple of logic changes to load_thread for deciding which post shows up as the primary post and which are replies. 

also fixes some formatting issues on the mod queue, and fixes how sender names were being converted to lowercase (it should just be their email address.) 
