### PR TITLE
various improvements from testing 

### DIFF
--- a/browser/templates/squadbox/thread.html
+++ b/browser/templates/squadbox/thread.html
@@ -16,8 +16,8 @@
 				{% else %}
 					<span class="not-verified" title="We could not verify the sender\'s identity - be cautious!">&#9888;</span>
 				{% endif %}
-				<br><span class="strong">To: </span>
-				<span class="strong-gray">{{ active_group.name }}</span> 
+<!-- 				<br><span class="strong">To: </span>
+				<span class="strong-gray">{{ active_group.name }}</span>  -->
 				<br>
 				<span class="strong">Date: </span>
 				<span class="strong-gray">{{ thread.post.timestamp }}</span>

--- a/browser/util.py
+++ b/browser/util.py
@@ -164,4 +164,8 @@ def fix_html_and_img_srcs(msg_id, post_text):
         if match:
             i['src'] = "attachment/" + match.hash_filename
 
+    style = post_soup.find_all('style')
+    for s in style:
+        s.replace_with('')
+
     return clean(str(post_soup), tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES)

--- a/browser/views.py
+++ b/browser/views.py
@@ -1597,7 +1597,8 @@ def mod_queue(request, group_name):
 def subscribe_confirm(request, token):
 	mgp = MemberGroupPending.objects.get(hash=token)
 	if mgp:
-		mg,_ = MemberGroup.objects.get_or_create(member=mgp.member, group=mgp.group)
+		mod = WEBSITE == 'squadbox'
+		mg,_ = MemberGroup.objects.get_or_create(member=mgp.member, group=mgp.group, moderator=mod)
 		MemberGroupPending.objects.get(hash=token).delete()
 		return HttpResponseRedirect('/')
 	else:

--- a/browser/views.py
+++ b/browser/views.py
@@ -1598,7 +1598,6 @@ def subscribe_confirm(request, token):
 	mgp = MemberGroupPending.objects.get(hash=token)
 	if mgp:
 		mod = WEBSITE == 'squadbox'
-		logging.debug("confirming; mod=%s" % mod)
 		mg,_ = MemberGroup.objects.get_or_create(member=mgp.member, group=mgp.group, moderator=mod)
 		MemberGroupPending.objects.get(hash=token).delete()
 		return HttpResponseRedirect('/')

--- a/browser/views.py
+++ b/browser/views.py
@@ -236,11 +236,9 @@ def thread(request):
 		member_group = MemberGroup.objects.filter(member=user, group=group)
 		is_member = member_group.exists()
 
-
+		modal_data = None
 		if is_member and (member_group[0].moderator or member_group[0].admin):
 			modal_data = group.mod_rules
-		else:
-			modal_data = None
 		
 		active_group = load_groups(request, groups, user, group_name=group.name)
 		if group.public or is_member:
@@ -251,13 +249,13 @@ def thread(request):
 				res = engine.main.load_thread(thread, user=request.user)
 				role = None
 
-			print res
-
 			if WEBSITE == 'murmur':
 				thread_to = '%s@%s' % (group.name, HOST) 
 			elif WEBSITE == 'squadbox':
 				admin = MemberGroup.objects.get(group=group, admin=True)
 				thread_to = admin.member.email
+
+
 			return {'user': request.user, 'groups': groups, 'thread': res, 'thread_to' : thread_to, 
 					'post_id': post_id, 'active_group': active_group, 'website' : WEBSITE, 
 					'active_group_role' : role, 'groups_links' : groups_links, 'modal_data' : modal_data}

--- a/browser/views.py
+++ b/browser/views.py
@@ -1598,6 +1598,7 @@ def subscribe_confirm(request, token):
 	mgp = MemberGroupPending.objects.get(hash=token)
 	if mgp:
 		mod = WEBSITE == 'squadbox'
+		logging.debug("confirming; mod=%s" % mod)
 		mg,_ = MemberGroup.objects.get_or_create(member=mgp.member, group=mgp.group, moderator=mod)
 		MemberGroupPending.objects.get(hash=token).delete()
 		return HttpResponseRedirect('/')

--- a/engine/main.py
+++ b/engine/main.py
@@ -1587,7 +1587,14 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				message_text['plain'] = html2text(html_prefix + p.post)
 				mail.Html = get_new_body(message_text, html_blurb, 'html')
 				mail.Body = get_new_body(message_text, plain_blurb, 'plain')
-				relay_mailer.deliver(mail, To = admin.email)
+
+				to_email = admin.email
+				if to_email.endswith('@gmail.com'):
+					filter_hash = mgs[0].gmail_filter_hash
+					gmail_id = to_email.split('@')[0] 
+					to_email = '%s+%s@gmail.com' % (gmail_id, filter_hash)
+
+				relay_mailer.deliver(mail, To = to_email)
 
 	except Post.DoesNotExist:
 		res['code'] = msg_code['POST_NOT_FOUND_ERROR']

--- a/engine/main.py
+++ b/engine/main.py
@@ -1,4 +1,4 @@
-import base64, email, hashlib, json, logging, random, re, sys
+import base64, email, hashlib, json, logging, random, re, sys, time
 
 from bleach import clean
 from cgi import escape
@@ -1721,4 +1721,22 @@ def adjust_moderate_user_for_thread(user, group_name, sender_addr, subject, mode
 		res['code'] = msg_code['NOT_MEMBER']
 
 	return res
+
+def generate_filter_hash(user, group_name):
+	res = {'status' : False }
+	try:
+		mg = MemberGroup.objects.get(member=user, group__name=group_name)
+		salt = hashlib.sha1(str(random.random())+str(time.time())).hexdigest()
+		new_hash = hashlib.sha1(user.email + group_name + salt).hexdigest()[:20]
+		mg.gmail_filter_hash = new_hash
+		mg.save()
+
+		res['status'] = True
+		res['hash'] = new_hash
+
+	except MemberGroup.DoesNotExist:
+		res['error'] = 'Member group does not exist'
+
+	return res
+
 

--- a/engine/main.py
+++ b/engine/main.py
@@ -1577,8 +1577,10 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				if orig_subj.startswith('Re: '):
 					orig_subj = orig_subj[4:]		
 
-				html_blurb = unicode(ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, True))
-				plain_blurb = ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, False)
+				# html_blurb = unicode(ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, True))
+				# plain_blurb = ps_squadbox(p.poster_email, reason, group_name, g.auto_approve_after_first, orig_subj, p.who_moderated.email, False)
+				html_blurb = ''
+				plain_blurb = ''
 
 				html_prefix = ''
 				if new_status == 'R' and len(p.mod_explanation) > 0:

--- a/engine/main.py
+++ b/engine/main.py
@@ -1495,9 +1495,13 @@ def update_blacklist_whitelist(user, group_name, emails, whitelist, blacklist):
 def update_post_status(user, group_name, post_id, new_status, explanation=None, tags=None):
 	res = {'status' : False}
 
+	logging.error("here, updating post status")
+
 	try:
 		p = Post.objects.get(id=post_id)
 		g = Group.objects.get(name=group_name)
+
+		logging.error("here2")
 		
 		# only admins or moderators of a group can change post statuses
 		mg = MemberGroup.objects.get(Q(admin=True) | Q(moderator=True), member=user, group=g)
@@ -1505,6 +1509,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 		if new_status not in ALLOWED_MESSAGE_STATUSES:
 			res['code'] = msg_code['INVALID_STATUS_ERROR'] % new_status
 		else:
+			logging.error("here3")
 			p.status = new_status
 			p.who_moderated = user
 
@@ -1528,9 +1533,13 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 			res['post_id'] = post_id
 			res['new_status'] = new_status
 
+			logging.error("here4")
+
 			# now send message on to the intended recipient if it was approved,
 			# or if it was rejected but the recipient wants rejected emails with tag
 			if new_status == 'A' or (new_status == 'R' and g.send_rejected_tagged):
+
+				logging.error("here5")
 
 				mgs = MemberGroup.objects.filter(group=g, admin=True)
 				if not mgs.exists():
@@ -1561,7 +1570,7 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 
 				res = download_message(p.id, p.msg_id)
 				if not res['status']:
-					logging.debug("Error downloading original message")
+					logging.error("Error downloading original message")
 				else:
 					original_msg = email.message_from_string(res['message'])
 					mail['In-Reply-To'] = original_msg['In-Reply-To']
@@ -1583,16 +1592,21 @@ def update_post_status(user, group_name, post_id, new_status, explanation=None, 
 				if new_status == 'R' and len(p.mod_explanation) > 0:
 					html_prefix = "<p><b>Moderator explanation for rejection</b>: %s </p><b>Message text</b>:<br>" % p.mod_explanation
 
+				logging.error("here6")
+
 				message_text = {'html' : html_prefix + p.post}
 				message_text['plain'] = html2text(html_prefix + p.post)
 				mail.Html = get_new_body(message_text, html_blurb, 'html')
 				mail.Body = get_new_body(message_text, plain_blurb, 'plain')
 
 				to_email = admin.email
+				logging.error("to email: %s" % to_email)
 				if to_email.endswith('@gmail.com'):
+					logging.error("here!")
 					filter_hash = mgs[0].gmail_filter_hash
 					gmail_id = to_email.split('@')[0] 
 					to_email = '%s+%s@gmail.com' % (gmail_id, filter_hash)
+					logging.error("updated to email: %s" % to_email)
 
 				relay_mailer.deliver(mail, To = to_email)
 

--- a/gmail_setup/api.py
+++ b/gmail_setup/api.py
@@ -142,7 +142,7 @@ def create_gmail_filter(service_mail, whitelist_emails, forward_address, filter_
         if 'forward' in f['action'] and f['action']['forward'] == forward_address:
             filters.delete(userId='me', id=f['id']).execute()
 
-    emails = '{from:' + ' from:'.join(whitelist_emails) + '}' 
+    emails = '{from:' + ' from:'.join(whitelist_emails) + ' from:me }' 
     gmail_secret = 'list:%s@%s' % (filter_hash, BASE_URL)
 
     new_filter = {

--- a/gmail_setup/api.py
+++ b/gmail_setup/api.py
@@ -36,27 +36,28 @@ def parse_gmail(service_mail):
         message = response
         list_message_object = {}
         batch_cb.stop = False
-        if int(message["internalDate"]) < int(current_time - time_back):
-            batch_cb.stop = True
-            return
-        for pair in message['payload']['headers']:
-            if pair["name"] == "From":
-                emailstring = pair["value"].encode('UTF-8')
-                list_message_object['email'] = re.findall(r'[\w\.-]+@[\w\.-]+', emailstring)[0]
-                name = emailstring.split('<')[0].strip()
-                if name.startswith('"') and name.endswith('"'):
-                    name = name[1:-1]
-                list_message_object['name'] = name
-        list_message_object['label'] = None
-        for label in message['labelIds']:
-            if label == "CATEGORY_PERSONAL": list_message_object['label'] = 'personal'
-            if label == "CATEGORY_SOCIAL": list_message_object['label'] = 'social'
-            if label == "CATEGORY_PROMOTIONS": list_message_object['label'] = 'promotions'
-            if label == "CATEGORY_UPDATES": list_message_object['label'] = 'updates'
-            if label == "CATEGORY_FORUMS": list_message_object['label'] = 'forums'
-        # TODO: labels at the moment are only decided based on most recent email; change to be mode
-        if list_message_object['label'] != None:
-            received_list.append(list_message_object)
+        if message is not None:
+            if int(message["internalDate"]) < int(current_time - time_back):
+                batch_cb.stop = True
+                return
+            for pair in message['payload']['headers']:
+                if pair["name"] == "From":
+                    emailstring = pair["value"].encode('UTF-8')
+                    list_message_object['email'] = re.findall(r'[\w\.-]+@[\w\.-]+', emailstring)[0]
+                    name = emailstring.split('<')[0].strip()
+                    if name.startswith('"') and name.endswith('"'):
+                        name = name[1:-1]
+                    list_message_object['name'] = name
+            list_message_object['label'] = None
+            for label in message['labelIds']:
+                if label == "CATEGORY_PERSONAL": list_message_object['label'] = 'personal'
+                if label == "CATEGORY_SOCIAL": list_message_object['label'] = 'social'
+                if label == "CATEGORY_PROMOTIONS": list_message_object['label'] = 'promotions'
+                if label == "CATEGORY_UPDATES": list_message_object['label'] = 'updates'
+                if label == "CATEGORY_FORUMS": list_message_object['label'] = 'forums'
+            # TODO: labels at the moment are only decided based on most recent email; change to be mode
+            if list_message_object['label'] != None:
+                received_list.append(list_message_object)
 
     # receieved:
     while (page_token != None) and time_not_over:

--- a/gmail_setup/views.py
+++ b/gmail_setup/views.py
@@ -26,7 +26,7 @@ CLIENT_SECRETS = os.path.join(os.path.dirname(__file__), 'client_secrets.json')
 def build_services(user):
     storage = Storage(CredentialsModel, 'id', user, 'credential')
     credential = storage.get()
-    if credential and not credential.invalid
+    if credential and not credential.invalid:
         http = httplib2.Http()
         http = credential.authorize(http)
         service_people = build('people', 'v1', http=http)
@@ -45,7 +45,7 @@ def index(request):
     group_name = request.GET['group']
     forward_address = group_name + '@' + BASE_URL
 
-    services = build_services(user)
+    services = build_services(request.user)
 
     is_authorized = False 
     # Used for Squadbox only:
@@ -56,7 +56,7 @@ def index(request):
         service_mail = services['mail']
         gmail_forwarding_verified = api.check_forwarding_address(service_mail, forward_address)
 
-    return {'website': WEBSITE, 'user': user, 'is_authorized': is_authorized, 'gmail_forwarding_verified': gmail_forwarding_verified, 'is_done': is_done, 'group_name': group_name, 'forward_address': forward_address}
+    return {'website': WEBSITE, 'user': request.user, 'is_authorized': is_authorized, 'gmail_forwarding_verified': gmail_forwarding_verified, 'is_done': is_done, 'group_name': group_name, 'forward_address': forward_address}
 
 @login_required
 def auth(request):
@@ -118,8 +118,8 @@ def deauth(request):
 
 @login_required
 def import_start(request):
-
-    services = build_services(request.user)
+    user = request.user
+    services = build_services(user)
     service_people = services['people']
     service_mail = services['mail']
 

--- a/gmail_setup/views.py
+++ b/gmail_setup/views.py
@@ -163,7 +163,7 @@ def import_start(request):
 
         for email in emails_to_add:
             # add these to whitelist / create form here!
-            res = update_blacklist_whitelist(user=user, group_name=group_name, email=email, whitelist=True, blacklist=False)
+            res = update_blacklist_whitelist(user, group_name, email, True, False)
 
         forward_address = group_name + '@' + BASE_URL
 

--- a/schema/models.py
+++ b/schema/models.py
@@ -159,6 +159,7 @@ class MemberGroup(models.Model):
 	receive_attachments = models.BooleanField(default=True)
 	last_emailed = models.DateTimeField(null=True)
 	gmail_filter_hash = models.CharField(max_length=40, null=True)
+	last_updated_hash = models.DateTimeField(auto_now_add=True)
 	
 	def __unicode__(self):
 		return '%s - %s' % (self.member.email, self.group.name)

--- a/schema/models.py
+++ b/schema/models.py
@@ -1,3 +1,4 @@
+
 from django.db import models
 from django.contrib.auth.models import BaseUserManager, AbstractBaseUser, User
 
@@ -157,6 +158,7 @@ class MemberGroup(models.Model):
 	upvote_emails = models.BooleanField(default=True)
 	receive_attachments = models.BooleanField(default=True)
 	last_emailed = models.DateTimeField(null=True)
+	gmail_filter_hash = models.CharField(max_length=40, null=True)
 	
 	def __unicode__(self):
 		return '%s - %s' % (self.member.email, self.group.name)
@@ -227,6 +229,7 @@ class WhiteOrBlacklist(models.Model):
 
 	# timestamp (for temporary bans)
 	timestamp = models.DateTimeField(auto_now=True)
+
 
 class MyUserManager(BaseUserManager):
 	def create_user(self, email, password=None):

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -599,7 +599,7 @@ def handle_post_squadbox(message, group, host, verified):
 		if to_email.endswith('@gmail.com'):
 			filter_hash = admin_mg.gmail_filter_hash
 			gmail_id = to_email.split('@')[0] 
-			to_email = '%s+%s@gmail.com' % (gmail_id, filter_hash)
+			to_email = '%s+__%s__@gmail.com' % (gmail_id, filter_hash)
 
 		relay.deliver(mail, To = to_email)
 

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -600,13 +600,11 @@ def handle_post_squadbox(message, group, host, verified):
 		plain_blurb = ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, False)
 		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
 
-		to_email = admin.email
-		if to_email.endswith('@gmail.com'):
-			filter_hash = admin_mg.gmail_filter_hash
-			gmail_id = to_email.split('@')[0] 
-			to_email = '%s+__%s__@gmail.com' % (gmail_id, filter_hash)
+		res = get_or_generate_filter_hash(admin, group.name)
+		if res['status']:
+			mail['List-Id'] = '%s@%s' % (res['hash'], BASE_URL)
+			logging.error("updated list id to %s" % mail['List-Id'])
 
-		mail['To'] = to_email
 		relay.deliver(mail)
 
 	# send notification to least recently emailed mod if we haven't emailed them in 24 hrs 

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -470,6 +470,11 @@ def handle_post_squadbox(message, group, host, verified):
 	sender_addr = sender_addr.lower()
 	if sender_name == '':
 		sender_name = None
+
+	# if this looks like a double-post, ignore it
+	if check_duplicate(message, group, sender_addr):
+		logging.debug("ignoring duplicate")
+		return
 	
 	subj = message['Subject'].strip()
 	message_is_reply = (subj[0:4].lower() == "re: ")
@@ -601,7 +606,8 @@ def handle_post_squadbox(message, group, host, verified):
 			gmail_id = to_email.split('@')[0] 
 			to_email = '%s+__%s__@gmail.com' % (gmail_id, filter_hash)
 
-		relay.deliver(mail, To = to_email)
+		mail['To'] = to_email
+		relay.deliver(mail)
 
 	# send notification to least recently emailed mod if we haven't emailed them in 24 hrs 
 	elif status == 'P':

--- a/smtp_handler/main.py
+++ b/smtp_handler/main.py
@@ -595,9 +595,11 @@ def handle_post_squadbox(message, group, host, verified):
 		add_attachments(mail, attachments)
 
 		html_blurb = unicode(ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, True))
+		html_blurb = ''
 		mail.Html = get_new_body(msg_text, html_blurb, 'html')
 
-		plain_blurb = ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, False)
+		#plain_blurb = ps_squadbox(sender_addr, reason, group.name, group.auto_approve_after_first, original_subj, None, False)
+		plain_blurb = ''
 		mail.Body = get_new_body(msg_text, plain_blurb, 'plain')
 
 		res = get_or_generate_filter_hash(admin, group.name)

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -73,7 +73,7 @@ ALLOWED_MIMETYPES = ["image/jpeg", "image/bmp", "image/gif", "image/png", "appli
 					"application/x-mspowerpoint", "application/powerpoint", "application/vnd.ms-powerpoint",
 					"application/msword", "text/plain", "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
 					"application/vnd.ms-excel", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", 
-					"application/vnd.openxmlformats-officedocument.presentationml.presentation"]
+					"application/vnd.openxmlformats-officedocument.presentationml.presentation", "application/pkcs7-signature"]
 
 ALLOWED_MIMETYPES_STR = 'images (JPEG, BMP, GIF, PNG), PDFs, and Microsoft Office (Word, Excel, Powerpoint) files'
 


### PR DESCRIPTION
Ok so as we discussed last meeting, needed a way to differentiate moderated messages using gmail filters. I first implemented this as the [sender gmail]+[secret hash]@gmail thing, but for whatever reason, the mail relay was stripping out the secret hashes on outgoing messages - i.e. on our end it was sent to "xxxx+hash@gmail", but by the time it got to gmail the "to" field was simply "xxxx@gmail". I spent a long time trying to fix it and couldn't figure it out so I gave up.

so I ended up switching to the other solution we'd talked about with setting the list-id of the message to be hash@squadbox. these do not get stripped out, and I think this is actually better because (unlike when the hash is in the "to' field) the hash is *not* carried through in forwarded messages. (and it isn't in replies, either.) 

what I have changed in this PR is: 
- a lot of automated emails have long <style> tags in them. strip these out when we display messages to moderators. in the long run, maybe want to figure out how to use those tags when rendering the email. someone clever might be able to manipulate style tag usage to do something malicious.
- two new MemberGroup fields, one containing the list-id hash and the other the last time we updated that hash. *you will need to do a migration. auto is fine, though it will ask you what value to put in the last_updated_hash column since default isn't specified. I would just use datetime.datetime.now() for existing columns* 
- the gmail filter we create now looks for that list-id and doesn't forward messages containing it.
- the gmail filter hash value is updated every 24 hours (easily changed to shorter or longer if we want) and the change is pushed to gmail via API. this is done in a lazy fashion - whenever we are sending the owner an email, we check if it's been longer than 24 hours, and update it if so. and then send the email with the newly changed hash as the list-id. 
- the gmail filter is updated anytime the squad owner updates their whitelist on the website. since we are already updating the filter, we will do the same > 24 hours check for the hash and change that if needed too. 
- removed the email footers containing info about squadbox for now. you can do a lot with labels on Gmail via the API and filters, so thinking maybe we can transfer at least some of that data to labels (for ex. add a "moderated" label so it's clear to user that a message went through moderation.) 
- the gmail filter now deletes the message before forwarding it to squadbox. 
- check for duplicate messages (same logic as used in murmur.) 
- some email clients add these .p7s attachments to outgoing messages. I guess it's a digital signature type thing. some of my personal emails had them and were getting rejected by squadbox for it, so we should probably allow this attachment type. 

all this stuff is running on the dev server now, so feel free to start testing with your own gmail on there now @amyxzhang. I have yet to give the contacts import and whitelist creation stuff any loading indicator or make it happen asynchronously, so you will just have to let the page sit and load for a bit while that happens.  