### PR TITLE
When group page is loaded, don't load entire message contents & attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ schema/migrations/*
 
 # Google secrets file
 gmail_setup/client_secrets.json
+
+sandbox/

--- a/browser/views.py
+++ b/browser/views.py
@@ -387,6 +387,17 @@ def group_list(request):
 	else:
 		return {'user': request.user, 'groups': groups, 'pub_groups': pub_groups, 'group_page': True}
 
+@render_to("login_imap.html")
+@login_required
+def login_imap_view(request):
+	user = get_object_or_404(UserProfile, email=request.user.email)
+	
+	try:
+		return {'user': request.user, 'website': WEBSITE, 'active_group_role' : 'admin'}
+
+	except Group.DoesNotExist:
+		return redirect('/404?e=admin')
+
 @render_to(WEBSITE+"/add_members.html")
 @login_required
 def add_members_view(request, group_name):
@@ -804,7 +815,8 @@ def donotsend_info(request):
 def list_posts(request):
 	try:
 		group_name = request.POST.get('active_group')
-		res = engine.main.list_posts(group_name=group_name, user=request.user.email)
+		load_replies = request.POST.get('load')
+		res = engine.main.list_posts(group_name=group_name, user=request.user.email, return_replies=load_replies)
 		res['user'] = request.user.email
 		res['group_name'] = group_name
 		return HttpResponse(json.dumps(res), content_type="application/json")

--- a/browser/views.py
+++ b/browser/views.py
@@ -850,6 +850,16 @@ def load_post(request):
 		return HttpResponse(request_error, content_type="application/json")
 
 @login_required
+def load_thread(request):
+	try:#request.user
+		t = Thread.objects.get(id=request.POST['thread_id'])
+		res = engine.main.load_thread(t, return_full_contents=False)
+		return HttpResponse(json.dumps(res), content_type="application/json")
+	except Exception, e:
+		logging.debug(e)
+		return HttpResponse(request_error, content_type="application/json")
+
+@login_required
 def insert_post(request):
 	try:
 		user = get_object_or_404(UserProfile, email=request.user.email)

--- a/browser/views.py
+++ b/browser/views.py
@@ -815,8 +815,8 @@ def donotsend_info(request):
 def list_posts(request):
 	try:
 		group_name = request.POST.get('active_group')
-		load_replies = request.POST.get('load')
-		return_full_content = request.POST.get('return_full_content')
+		load_replies = True if request.POST.get('load') == "true" else False
+		return_full_content = True if request.POST.get('return_full_content') == "true" else False
 		res = engine.main.list_posts(group_name=group_name, user=request.user.email, return_replies=load_replies, return_full_content=return_full_content)
 		res['user'] = request.user.email
 		res['group_name'] = group_name

--- a/browser/views.py
+++ b/browser/views.py
@@ -816,7 +816,8 @@ def list_posts(request):
 	try:
 		group_name = request.POST.get('active_group')
 		load_replies = request.POST.get('load')
-		res = engine.main.list_posts(group_name=group_name, user=request.user.email, return_replies=load_replies)
+		return_full_content = request.POST.get('return_full_content')
+		res = engine.main.list_posts(group_name=group_name, user=request.user.email, return_replies=load_replies, return_full_content=return_full_content)
 		res['user'] = request.user.email
 		res['group_name'] = group_name
 		return HttpResponse(json.dumps(res), content_type="application/json")
@@ -853,7 +854,7 @@ def load_post(request):
 def load_thread(request):
 	try:#request.user
 		t = Thread.objects.get(id=request.POST['thread_id'])
-		res = engine.main.load_thread(t, return_full_contents=False)
+		res = engine.main.load_thread(t)
 		return HttpResponse(json.dumps(res), content_type="application/json")
 	except Exception, e:
 		logging.debug(e)

--- a/engine/main.py
+++ b/engine/main.py
@@ -783,8 +783,8 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
                 post_dict['forwarding_list'] = p.forwarding_list.email
             if not p.reply_to:
                 post = post_dict
-                if not return_replies:
-                    break
+                # if not return_replies:
+                #     break
             else:
                 replies.append(post_dict)
         
@@ -794,7 +794,7 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
         res['threads'].append({'thread_id': t.id, 
                                'post': post, 
                                'num_replies': len(replies) - 1,
-                               'replies': replies, 
+                               'replies': replies if return_replies else [], 
                                'following': following, 
                                'muting': muting,
                                'tags': tags,

--- a/engine/main.py
+++ b/engine/main.py
@@ -793,7 +793,7 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
         tags = list(Tag.objects.filter(tagthread__thread=t).values('name', 'color'))
         res['threads'].append({'thread_id': t.id, 
                                'post': post, 
-                               'num_replies': len(replies) - 1,
+                               'num_replies': len(replies),
                                'replies': replies if return_replies else [], 
                                'following': following, 
                                'muting': muting,

--- a/engine/main.py
+++ b/engine/main.py
@@ -873,7 +873,7 @@ def load_thread(t, user=None, member=None):
                     'liked': user_liked,
                     'subject': escape(p.subject), 
                     'text' : fix_html_and_img_srcs(p.msg_id, p.post),
-                    'timestamp': p.timestamp,
+                    'timestamp': format_date_time(p.timestamp),
                     'attachments': attachments,
                     'verified': p.verified_sender,
                     'who_moderated' : p.who_moderated,
@@ -911,7 +911,7 @@ def load_thread(t, user=None, member=None):
             'no_emails': no_emails,
             'always_follow': always_follow,
             'likes': total_likes,
-            'timestamp': t.timestamp}
+            'timestamp': format_date_time(t.timestamp)}
 
 def load_post(group_name, thread_id, msg_id):
     res = {'status':False}

--- a/engine/main.py
+++ b/engine/main.py
@@ -779,7 +779,7 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
                         }
             if p.forwarding_list:
                 post_dict['forwarding_list'] = p.forwarding_list.email
-            if not p.reply_to_id:
+            if not p.reply_to:
                 post = post_dict
                 if not return_replies:
                     break
@@ -791,7 +791,7 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
         tags = list(Tag.objects.filter(tagthread__thread=t).values('name', 'color'))
         res['threads'].append({'thread_id': t.id, 
                                'post': post, 
-                               'num_replies': posts.count() - 1,
+                               'num_replies': len(replies) - 1,
                                'replies': replies, 
                                'following': following, 
                                'muting': muting,

--- a/engine/main.py
+++ b/engine/main.py
@@ -790,6 +790,8 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
         
         if not_include_thread:
             continue
+        if not post: # assert the post exists 
+            continue
         tags = list(Tag.objects.filter(tagthread__thread=t).values('name', 'color'))
         res['threads'].append({'thread_id': t.id, 
                                'post': post, 

--- a/engine/main.py
+++ b/engine/main.py
@@ -822,7 +822,7 @@ def list_posts(group_name=None, user=None, timestamp_str=None, return_replies=Tr
     logging.debug(res)
     return res
     
-def load_thread(t, user=None, member=None):
+def load_thread(t, user=None, member=None, return_full_contents=True):
 
     following = False
     muting = False
@@ -855,11 +855,14 @@ def load_thread(t, user=None, member=None):
         if user:
             user_liked = p.upvote_set.filter(user=user).exists()
         attachments = []
-        for attachment in Attachment.objects.filter(msg_id=p.msg_id):
-            url = "attachment/" + attachment.hash_filename
-            attachments.append((attachment.true_filename, url))
 
+        # Get attachments only when asked to return full contents
+        if return_full_contents:
+            for attachment in Attachment.objects.filter(msg_id=p.msg_id):
+                url = "attachment/" + attachment.hash_filename
+                attachments.append((attachment.true_filename, url))
 
+        post_full_text = fix_html_and_img_srcs(p.msg_id, p.post)
         post_dict = {
                     'id': str(p.id),
                     'msg_id': p.msg_id, 
@@ -869,7 +872,7 @@ def load_thread(t, user=None, member=None):
                     'to': p.group.name,
                     'liked': user_liked,
                     'subject': escape(p.subject), 
-                    'text' : fix_html_and_img_srcs(p.msg_id, p.post),
+                    'text' : post_full_text if return_full_contents else post_full_text[:40],
                     'timestamp': p.timestamp,
                     'attachments': attachments,
                     'verified': p.verified_sender,

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -524,7 +524,8 @@ $(document).ready(function(){
 					if(res.status){
 						list_posts({'load':true, 
 									'active_group': params.group_name,
-									'thread_id':res.thread_id});
+									'thread_id':res.thread_id,
+									'return_full_content': false});
 					}
 					notify(res, true);
 				}
@@ -1263,7 +1264,7 @@ $(document).ready(function(){
                         }
                 );
         var active_group = $("#active_group").text();
-		list_posts({'load':false, 'active_group': active_group});
+		list_posts({'load':false, 'active_group': active_group, return_full_content=false});
 		activate_tag_buttons(active_group);
 	}
 	

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -827,7 +827,7 @@ $(document).ready(function(){
 			var content = '<div class="left-column-area-metadata">';
 			content += '<span class="gray">' + d.date + '</span><BR>';
 			content += '<span class="gray">' + d.time + '</span><BR>';
-			content += '<span class="unread">' + thread_list[i].replies.length + '</span> <br />';
+			content += '<span class="unread">' + thread_list[i].num_replies + '</span> <br />';
 			content += '</div>';
 			content += '<div class= "left-column-area-content">';
 			

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -1264,7 +1264,7 @@ $(document).ready(function(){
                         }
                 );
         var active_group = $("#active_group").text();
-		list_posts({'load':false, 'active_group': active_group, return_full_content=false});
+		list_posts({'load':false, 'active_group': active_group, 'return_full_content':false});
 		activate_tag_buttons(active_group);
 	}
 	

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -285,8 +285,21 @@ $(document).ready(function(){
 
 
 
-	load_post = 
+	load_thread = 
 		function(params){
+			// TODO load posts at a thread; need to include msg_id, group_name
+			$.post('load_thread', params, 
+				function(res){
+					params.thread_id = parseInt(getUrlParameter('tid'));
+					if (params.thread_id > -1) {
+						params.load = true;
+					}
+					if (res.status) {
+						populate_posts_table(res, params, true);
+					}
+				}
+			);
+			
 			render_post(params);
 			posts_local_data.selected_thread = params.thread_id;
 			$('.row-item').css("background-color","white");
@@ -869,7 +882,7 @@ $(document).ready(function(){
 				 'member_group': member_group,
 			};
 				
-			var f = bind(load_post, params);
+			var f = bind(load_thread, params);
 			if(thread_list[i].thread_id == load_params.thread_id){
 				selected_thread = thread_list[i].thread_id;
 			}

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -294,7 +294,7 @@ $(document).ready(function(){
 						params.load = true;
 					}
 					if (res.status) {
-						render_post(params);
+						render_post(res);
 					}
 				}
 			);

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -295,14 +295,13 @@ $(document).ready(function(){
 					}
 					if (res.status) {
 						render_post(res);
+
+						posts_local_data.selected_thread = params.thread_id;
+						$('.row-item').css("background-color","white");
+						$('#' + params.thread_id).css("background-color","lightyellow");
 					}
 				}
 			);
-			
-			
-			posts_local_data.selected_thread = params.thread_id;
-			$('.row-item').css("background-color","white");
-			$('#' + params.thread_id).css("background-color","lightyellow");
 		};
 
 	

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -289,10 +289,6 @@ $(document).ready(function(){
 		function(params){
 			$.post('load_thread', params, 
 				function(res){
-					params.thread_id = parseInt(getUrlParameter('tid'));
-					if (params.thread_id > -1) {
-						params.load = true;
-					}
 					if (res.status) {
 						render_post(res);
 

--- a/http_handler/static/javascript/murmur/main.js
+++ b/http_handler/static/javascript/murmur/main.js
@@ -284,10 +284,9 @@ $(document).ready(function(){
     };
 
 
-
+	// Load posts at a thread
 	load_thread = 
 		function(params){
-			// TODO load posts at a thread; need to include msg_id, group_name
 			$.post('load_thread', params, 
 				function(res){
 					params.thread_id = parseInt(getUrlParameter('tid'));
@@ -295,12 +294,12 @@ $(document).ready(function(){
 						params.load = true;
 					}
 					if (res.status) {
-						populate_posts_table(res, params, true);
+						render_post(params);
 					}
 				}
 			);
 			
-			render_post(params);
+			
 			posts_local_data.selected_thread = params.thread_id;
 			$('.row-item').css("background-color","white");
 			$('#' + params.thread_id).css("background-color","lightyellow");

--- a/http_handler/urls.py
+++ b/http_handler/urls.py
@@ -119,6 +119,7 @@ if WEBSITE == 'murmur':
                     url(r'^list_my_groups', 'browser.views.list_my_groups'), 
 
                     url(r'^load_post', 'browser.views.load_post'),
+                    url(r'^load_thread', 'browser.views.load_thread'),
 
                     url(r'^list_posts', 'browser.views.list_posts'),
                     url(r'^refresh_posts', 'browser.views.refresh_posts'),

--- a/schema/models.py
+++ b/schema/models.py
@@ -284,7 +284,7 @@ class UserProfile(AbstractBaseUser):
 	is_admin = models.BooleanField(default=False)
 	date_joined = models.DateTimeField(auto_now=True)
 	hash = models.CharField(max_length=40, default="")
-	imapAccount = models.ForeignKey('ImapAccount', blank=True)
+	imapAccount = models.ForeignKey('ImapAccount', blank=True, null=True)
 
 	objects = MyUserManager()
 

--- a/schema/models.py
+++ b/schema/models.py
@@ -13,7 +13,7 @@ class Post(models.Model):
 	author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='user_authored_posts', null=True)
 	subject = models.TextField()
 	msg_id = models.CharField(max_length=120, unique=True)
-	post = models.TextField(max_length=1255)
+	post = models.TextField()
 	group = models.ForeignKey('Group')
 	thread = models.ForeignKey('Thread')
 	reply_to = models.ForeignKey('self', blank=False, null=True, related_name="replies")

--- a/schema/models.py
+++ b/schema/models.py
@@ -13,7 +13,7 @@ class Post(models.Model):
 	author = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='user_authored_posts', null=True)
 	subject = models.TextField()
 	msg_id = models.CharField(max_length=120, unique=True)
-	post = models.TextField()
+	post = models.TextField(max_length=1255)
 	group = models.ForeignKey('Group')
 	thread = models.ForeignKey('Thread')
 	reply_to = models.ForeignKey('self', blank=False, null=True, related_name="replies")
@@ -284,6 +284,7 @@ class UserProfile(AbstractBaseUser):
 	is_admin = models.BooleanField(default=False)
 	date_joined = models.DateTimeField(auto_now=True)
 	hash = models.CharField(max_length=40, default="")
+	imapAccount = models.ForeignKey('ImapAccount', blank=True)
 
 	objects = MyUserManager()
 
@@ -319,6 +320,25 @@ class UserProfile(AbstractBaseUser):
 		"Is the user a member of staff?"
 		return self.is_admin
 
+class ImapAccount(models.Model):
+	newest_msg_id = models.IntegerField(default=-1)
+
+	email = models.EmailField(
+        verbose_name='email address',
+        max_length=255,
+        unique=True,
+    )
+	password = models.CharField('password', max_length=100, blank=True)
+	host = models.CharField('host', max_length=100)
+
+	is_oauth = models.BooleanField(default=False)
+	access_token = models.CharField('access_token', max_length=100, blank=True)
+	refresh_token = models.CharField('refresh_token', max_length=100, blank=True)
+	
+	arrive_action = models.CharField('access_token', max_length=1000, blank=True)
+	custom_action = models.CharField('custom_action', max_length=1000, blank=True)
+	timer_action = models.CharField('timer_action', max_length=1000, blank=True)
+	repeat_action = models.CharField('repeat_action', max_length=1000, blank=True)
 
 class Following(models.Model):
 	id = models.AutoField(primary_key=True)

--- a/smtp_handler/management/commands/digest.py
+++ b/smtp_handler/management/commands/digest.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             # Get lists of subjects of posts for given time span
             now = datetime.now()
             lastday_time = now - timedelta(hours = 24)
-            posts = Post.objects.filter(timestamp__range=(lastday_time,now))
+            posts = Post.objects.filter(timestamp__range=(lastday_time,now), group=group)
             if not posts.exists():
                 continue
 
@@ -48,4 +48,11 @@ class Command(BaseCommand):
                 
                 if digest_body != "":
                     digest_body = "Today's topics: <br/>" + digest_body
+
+                addr = EDIT_SETTINGS_ADDR % (HOST, group.name)
+                footer = "You are set to receive daily digests from this group. <BR><a href=\"%s\">Change your settings</a>" % (addr)
+
+                footer = '%s%s%s' % (HTML_SUBHEAD, footer, HTML_SUBTAIL)
+                digest_body = digest_body + footer
+
                 send_email(digest_subject, DEFAULT_FROM_EMAIL, mg.member.email, body_html=digest_body)

--- a/smtp_handler/management/commands/digest.py
+++ b/smtp_handler/management/commands/digest.py
@@ -52,7 +52,7 @@ class Command(BaseCommand):
                 addr = EDIT_SETTINGS_ADDR % (HOST, group.name)
                 footer = "You are set to receive daily digests from this group. <BR><a href=\"%s\">Change your settings</a>" % (addr)
 
-                footer = '%s%s%s' % (HTML_SUBHEAD, footer, HTML_SUBTAIL)
+                footer = '<br/>%s%s%s' % (HTML_SUBHEAD, footer, HTML_SUBTAIL)
                 digest_body = digest_body + footer
 
                 send_email(digest_subject, DEFAULT_FROM_EMAIL, mg.member.email, body_html=digest_body)

--- a/smtp_handler/utils.py
+++ b/smtp_handler/utils.py
@@ -192,7 +192,7 @@ def setup_moderation_post(group_name):
 def send_email(subject, from_addr, to_addr, body_plain=None, body_html=None):
 	mail = MurmurMailResponse(From = from_addr, Subject = subject)
 	if body_plain:
-		mail.Body = body
+		mail.Body = body_plain
 	if body_html:
 		mail.Html = body_html
 


### PR DESCRIPTION
Currently, when a group page is loaded, Murmur fetches entire thread messages & attachments which makes super slow to load the page. 

Instead, I change when the page is loaded only metadata (e.g. the original author, number of msg at thread, first 20 letters of content) of each thread is loaded. And attachment& content of individual email are loaded when a user clicks a thread to view. 