### PR TITLE
Created friendly group name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,7 @@
 # Please enter your gmail address
 # Also create an gmail app password
-GMAIL_USER=YOUR_GMAIL_ACCOUNT@GMAIL.COM
-GMAIL_PASSWORD=YOUR_APP_PASSWORD
-
+GMAIL_USER=angelica.castillejoss@GMAIL.COM
+GMAIL_PASSWORD=ivuhzrgjsmaiyefg
 
 
 

--- a/browser/templates/mobile_list_groups.html
+++ b/browser/templates/mobile_list_groups.html
@@ -26,7 +26,11 @@
 					<a href="{{ link }}">
 					{% endif %}
 						<li class="row-item" id="{{ group.name }}">
-							<span class="strong">{{ group.name }}</span>
+							{% if group.friendly_name != "" %}
+								<span class="strong">{{ group.friendly_name }}</span>
+							{% else %}
+								<span class="strong">{{ group.name }}</span>
+							{% endif %}
 							{% if group.admin %}
 								<span class="admin label">
 								{% if website == 'murmur' %}

--- a/browser/templates/murmur/add_donotsend.html
+++ b/browser/templates/murmur/add_donotsend.html
@@ -2,7 +2,11 @@
 
 {% block container-content %}
 	
-	<h3>Add email addresses to do-not-send for <span id="group-name">{{ group_info.name }}</span></h3>
+	{% if group_info.friendly_name != '' %}
+		<h3>Add email addresses to do-not-send for <span id="group-name">{{ group_info.friendly_name }}</span></h3>
+	{% else %}
+		<h3>Add email addresses to do-not-send for <span id="group-name">{{ group_info.name }}</span></h3>
+	{% endif %}
 	<hr>
 	
 	<form id="new-members-form">

--- a/browser/templates/murmur/add_list.html
+++ b/browser/templates/murmur/add_list.html
@@ -19,9 +19,14 @@
 	        <input id="new-list-email" type="text" size="40"></input><br/>
 	        <span class="strong">List URL (optional): </span> <br />
 	        <input id="new-list-url" type="text" size="40"></input><br/> 
-	        <br/>
-			<input type="checkbox" id="can_post"> Allow emails from the above mailing list to be posted to {{ group_info.friendly_name }}<br/>
-			<input type="checkbox" id="can_receive"> Forward posts from {{ group_info.friendly_name }} to the above mailing list<br/>
+			<br/>
+			{% if group_info.friendly_name != '' %}
+				<input type="checkbox" id="can_post"> Allow emails from the above mailing list to be posted to {{ group_info.friendly_name }}<br/>
+				<input type="checkbox" id="can_receive"> Forward posts from {{ group_info.friendly_name }} to the above mailing list<br/>
+			{% else %}
+				<input type="checkbox" id="can_post"> Allow emails from the above mailing list to be posted to {{ group_info.name }}<br/>
+				<input type="checkbox" id="can_receive"> Forward posts from {{ group_info.name }} to the above mailing list<br/>
+			{% endif %}
 	        <br /> <br />
 			<button type="button" id="btn-add-list" style="margin-top:10px;">Add List</button>
 		</form>

--- a/browser/templates/murmur/add_list.html
+++ b/browser/templates/murmur/add_list.html
@@ -8,17 +8,20 @@
 <div class="container">
   <div class="group-container">
 	
-     <h3>Add New Associated Mailing List to <span id="group-name">{{ group_info.name }}</span></h3>
-
-     <hr />
+	{% if group_info.friendly_name != '' %}
+     	<h3>Add New Associated Mailing List to <span id="group-name">{{ group_info.friendly_name }}</span></h3>
+	{% else %}
+		<h3>Add New Associated Mailing List to <span id="group-name">{{ group_info.name }}</span></h3>
+	{% endif %}
+     <hr/>
         <form id="new-list-form">
 			<span class="strong">List email address: </span> <br />
 	        <input id="new-list-email" type="text" size="40"></input><br/>
 	        <span class="strong">List URL (optional): </span> <br />
 	        <input id="new-list-url" type="text" size="40"></input><br/> 
 	        <br/>
-			<input type="checkbox" id="can_post"> Allow emails from the above mailing list to be posted to {{ group_info.name }}<br/>
-			<input type="checkbox" id="can_receive"> Forward posts from {{ group_info.name }} to the above mailing list<br/>
+			<input type="checkbox" id="can_post"> Allow emails from the above mailing list to be posted to {{ group_info.friendly_name }}<br/>
+			<input type="checkbox" id="can_receive"> Forward posts from {{ group_info.friendly_name }} to the above mailing list<br/>
 	        <br /> <br />
 			<button type="button" id="btn-add-list" style="margin-top:10px;">Add List</button>
 		</form>

--- a/browser/templates/murmur/add_members.html
+++ b/browser/templates/murmur/add_members.html
@@ -4,9 +4,9 @@
 	<h3>Add New Members to 
 		{% if group_info.friendly_name != '' %}
 			<span id="friendly-name">{{ group_info.friendly_name }}</span>
-		{%else%}
+		{% else %}
 			<span id="friendly-name">{{ group_info.name }}</span>
-		{%endif%}
+		{% endif %}
 	</h3>
 	<hr />
 	

--- a/browser/templates/murmur/add_members.html
+++ b/browser/templates/murmur/add_members.html
@@ -1,7 +1,13 @@
 {% extends "group_container_base.html" %}
 
 {% block container-content %}
-	<h3>Add New Members to <span id="group-name">{{ group_info.name }}</span></h3>
+	<h3>Add New Members to 
+		{% if group_info.friendly_name != '' %}
+			<span id="friendly-name">{{ group_info.friendly_name }}</span>
+		{%else%}
+			<span id="friendly-name">{{ group_info.name }}</span>
+		{%endif%}
+	</h3>
 	<hr />
 	
 	<form id="new-members-form">

--- a/browser/templates/murmur/base.html
+++ b/browser/templates/murmur/base.html
@@ -58,10 +58,18 @@
           	
           	{% if not group_page %}
 	            <li class="dropdown dropdown-left">
-	              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><span id="active_group">{{ active_group.name }}</span><span class="caret"></span></a>
+					{% if active_group.friendly_name != '' %}
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown"><span id="active_group">{{ active_group.friendly_name }}</span><span class="caret"></span></a>
+					{% else %}
+						<a href="#" class="dropdown-toggle" data-toggle="dropdown"><span id="active_group">{{ active_group.name }}</span><span class="caret"></span></a>
+					{% endif %}
 	              <ul class="dropdown-menu" role="menu">
-	              	{% for group in groups %}
-	                	<li><a href="/posts?group_name={{ group.name }}">{{ group.name }}</a></li>
+					  {% for group in groups %}
+					  	{% if group.friendly_name != '' %}
+							<li><a href="/posts?group_name={{ group.name }}">{{ group.friendly_name }}</a></li>
+						{% else %}
+							<li><a href="/posts?group_name={{ group.name }}">{{ group.name }}</a></li>
+						{% endif %}
 					{% endfor %}
 	                <li class="divider"></li>
 	                <li><a href="/my_groups">Manage my groups</a></li>
@@ -82,9 +90,13 @@
 	              	<ul class="dropdown-menu" role="menu" id="list-group-names">
 		              	{% for group in groups %}
 		              		{% if group.name == active_group %}
-		              			<li><a href="/posts?group_name={{ group.name }}"><span id="active_group">{{ group.name }}</span></a></li>
-		              		{% else %}
-		                		<li><a href="/posts?group_name={{ group.name }}">{{ group.name }}</a></li>
+		              			<li><a href="/posts?group_name={{ group.name }}"><span id="active_group">{{ 'yer' }}</span></a></li>
+							{% else %}
+								{% if group.friendly_name != '' %}
+									<li><a href="/posts?group_name={{ group.name }}">{{ group.friendly_name }}</a></li>
+								{% else %}
+									<li><a href="/posts?group_name={{ group.name }}">{{ group.name }}</a></li>
+								{% endif %}
 		                	{% endif %}
 						{% endfor %}
 	                <li class="divider"></li>

--- a/browser/templates/murmur/base.html
+++ b/browser/templates/murmur/base.html
@@ -90,8 +90,8 @@
 	              	<ul class="dropdown-menu" role="menu" id="list-group-names">
 		              	{% for group in groups %}
 		              		{% if group.name == active_group %}
-		              			<li><a href="/posts?group_name={{ group.name }}"><span id="active_group">{{ 'yer' }}</span></a></li>
-							{% else %}
+							  <li><a href="/posts?group_name={{ group.name }}"><span id="active_group">{{ group.name }}</span></a></li>
+							  {% else %}
 								{% if group.friendly_name != '' %}
 									<li><a href="/posts?group_name={{ group.name }}">{{ group.friendly_name }}</a></li>
 								{% else %}

--- a/browser/templates/murmur/create_post.html
+++ b/browser/templates/murmur/create_post.html
@@ -7,12 +7,15 @@
 
 <div class="container">
   <div class="group-container">
-	
-	<h3>Send Post to <span id="group-name">{{ group_info.name }}</span></h3><hr />
+		{% if group_info.friendly_name != '' %}   
+			<h3>Send Post to <span id="group-name">{{ group_info.friendly_name }}</span></h3><hr />
+		{% else %}
+			<h3>Send Post to <span id="group-name">{{ group_info.name }}</span></h3><hr />
+		{% endif %}
    		<span class="strong">
    			To : 
    		</span>
-   		<span id="new-post-to">{{ group_info.name }}</span>
+		<a href="mailto:{{admin_address}}" target="_newtab">{{admin_address}}</a>
    		<br>
    		<span class="strong">
    			Subject : 

--- a/browser/templates/murmur/create_post.html
+++ b/browser/templates/murmur/create_post.html
@@ -14,7 +14,8 @@
 		{% endif %}
    		<span class="strong">
    			To : 
-   		</span>
+		</span>
+		<p hidden id="new-post-to">{{ group_info.name }}</p>   
 		<a href="mailto:{{admin_address}}" target="_newtab">{{admin_address}}</a>
    		<br>
    		<span class="strong">

--- a/browser/templates/murmur/edit_create_group.html
+++ b/browser/templates/murmur/edit_create_group.html
@@ -16,8 +16,13 @@
 	</span>
 	<br>
 	{% if edit_page %}
-		<input id="group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;" value="{{group_info.name}}">
-		</input>
+		{% if group_info.friendly_name != '' %}
+			<input id="group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;" value="{{group_info.friendly_name}}">
+			</input>
+		{% else %}
+			<input id="group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;" value="{{group_info.name}}">
+			</input>
+		{% endif %}
 	{% else %}
 		<input id="group-name" maxlength="20" type="text" style="width: 100%; box-sizing: border-box;">
 		</input>

--- a/browser/templates/murmur/edit_my_settings.html
+++ b/browser/templates/murmur/edit_my_settings.html
@@ -8,8 +8,11 @@
 
 <div class="container">
   <div class="group-container">
-	
-	<h3>Edit My Settings for <span id="group-name">{{ group_info.name }}</span></h3><hr /><br />
+	{% if group_info.friendly_name != '' %}
+		<h3>Edit My Settings for <span id="group_name">{{ group_info.friendly_name }}</span></h3><hr /><br />
+	{% else %}
+		<h3>Edit My Settings for <span id="group_name">{{ group_info.name }}</span></h3><hr /><br />
+	{% endif %}
     <form id="group-settings-form">
 
 

--- a/browser/templates/murmur/group_page.html
+++ b/browser/templates/murmur/group_page.html
@@ -26,9 +26,9 @@
 			
 			<h3>
 				{% if group_info.group.friendly_name == "" %}
-				<span id="friendly-name">{{ group_info.group.name }}</span>
+				<span id="group-name">{{ group_info.group.name }}</span>
 				{% else %}
-				<span id="friendly-name">{{ group_info.group.friendly_name }}</span>
+				<span id="group-name">{{ group_info.group.friendly_name }}</span>
 				{% endif %}
 			</h3>
 

--- a/browser/templates/murmur/group_page.html
+++ b/browser/templates/murmur/group_page.html
@@ -26,9 +26,9 @@
 			
 			<h3>
 				{% if group_info.group.friendly_name == "" %}
-				<span id="group-name">{{ group_info.group.name }}</span>
+					<span id="group-name">{{ group_info.group.name }}</span>
 				{% else %}
-				<span id="group-name">{{ group_info.group.friendly_name }}</span>
+					<span id="group-name">{{ group_info.group.friendly_name }}</span>
 				{% endif %}
 			</h3>
 

--- a/browser/templates/murmur/group_page.html
+++ b/browser/templates/murmur/group_page.html
@@ -5,7 +5,7 @@
 {% block content %}
 	<div class="container">
 		<div class="group-container">
-			
+
 			{% if group_info.subscribed %}
 				<span class="member label">Member</span>
 			{% else %}
@@ -24,7 +24,14 @@
 				<span class="mod label" style="display: none;"></span>
 			{% endif %}
 			
-			<h3><span id="group-name">{{ group_info.group.name }}</span></h3>
+			<h3>
+				{% if group_info.group.friendly_name == "" %}
+				<span id="friendly-name">{{ group_info.group.name }}</span>
+				{% else %}
+				<span id="friendly-name">{{ group_info.group.friendly_name }}</span>
+				{% endif %}
+			</h3>
+
 			<hr/>
 			{% if group_info.group.description == "" %}
 				<span class="italic-med">No description</span>

--- a/browser/templates/murmur/mobile_list_posts.html
+++ b/browser/templates/murmur/mobile_list_posts.html
@@ -79,7 +79,11 @@
             {% endif %}
 
             <div style="display:none;" id="group_name">{{ active_group.name }}</div>
-            <h1>{{ active_group.name }}</h1>
+            {% if active_group.friendly_name != '' %}
+              <h1>{{ active_group.friendly_name }}</h1>
+            {% else %}
+              <h1>{{ active_group.name }}</h1>
+            {% endif %} 
             {% if active_group.description %}
             <i>{{ active_group.description }}</i>
             <br>
@@ -287,7 +291,7 @@
 <script type="text/javascript" src="/static/javascript/third-party/ckeditor/ckeditor.js"></script>
 <script type="text/javascript" src="/static/javascript/third-party/typeahead.js/typeahead.jquery.min.js"></script>
 <script type="text/javascript" src="/static/javascript/third-party/typeahead.js/bloodhound.min.js"></script>
-<script type="text/javascript" src="/static/javascript/murmur/main.js"></script>
+<script type="text/javascript" src="/static/javascript/murmur/mobile_list_posts"></script>
 <script>
 
   //select tags

--- a/browser/templates/murmur/mobile_list_posts.html
+++ b/browser/templates/murmur/mobile_list_posts.html
@@ -291,7 +291,7 @@
 <script type="text/javascript" src="/static/javascript/third-party/ckeditor/ckeditor.js"></script>
 <script type="text/javascript" src="/static/javascript/third-party/typeahead.js/typeahead.jquery.min.js"></script>
 <script type="text/javascript" src="/static/javascript/third-party/typeahead.js/bloodhound.min.js"></script>
-<script type="text/javascript" src="/static/javascript/murmur/mobile_list_posts"></script>
+<script type="text/javascript" src="/static/javascript/murmur/main.js"></script>
 <script>
 
   //select tags

--- a/browser/templates/murmur/thread.html
+++ b/browser/templates/murmur/thread.html
@@ -41,7 +41,7 @@
 					via {{ thread.post.forwarding_list }}
 					{% endif %}
 					<br><span class="strong">To: </span>
-					<span class="strong-gray">{{ active_group.name }}</span> 
+					<span class="strong-gray">{{ active_group.admin_address }}</span> 
 					<br>
 					<span class="strong">Date: </span>
 					<span class="strong-gray">{{ thread.post.timestamp }}</span> <br />

--- a/browser/views.py
+++ b/browser/views.py
@@ -147,6 +147,7 @@ def post_list(request):
 				for tag in tag_info:
 					tag.muted = tag.mutetag_set.filter(user=user, group=group).exists()
 					tag.followed = tag.followtag_set.filter(user=user, group=group).exists()
+
 			return {'user': request.user, 'groups': groups, 'posts': res, 'active_group': active_group, "tag_info": tag_info, 
 						"member_info": member_info, 'is_member': is_member}
 		else:
@@ -159,6 +160,7 @@ def post_list(request):
 			group = Group.objects.get(name=active_group['name'])
 			active_group['description'] = group.description
 			tag_info = Tag.objects.filter(group=group).annotate(num_p=Count('tagthread')).order_by('-num_p')
+			
 			if not group.public:
 				return redirect('/404?e=request_login')
 			else:

--- a/browser/views.py
+++ b/browser/views.py
@@ -815,7 +815,6 @@ def load_thread(request):
 @login_required
 def insert_post(request):
 	try:
-		logger.debug("insert post")
 		user = get_object_or_404(UserProfile, email=request.user.email)
 
 		group_name = request.POST['group_name']
@@ -831,7 +830,7 @@ def insert_post(request):
 			subj_tag += '[%s]' % tag['name']
 			
 		stripped_subj = re.sub("\[.*?\]", "", request.POST['subject'])
-		subject = '[%s]%s %s' %(friendly_name, subj_tag, stripped_subj)
+		subject = '[%s]%s %s' %( friendly_name if friendly_name != '' else group_name, subj_tag, stripped_subj)
 		
 		
 		msg_id = res['msg_id']

--- a/browser/views.py
+++ b/browser/views.py
@@ -147,7 +147,6 @@ def post_list(request):
 				for tag in tag_info:
 					tag.muted = tag.mutetag_set.filter(user=user, group=group).exists()
 					tag.followed = tag.followtag_set.filter(user=user, group=group).exists()
-			logger.debug('hit2')
 			return {'user': request.user, 'groups': groups, 'posts': res, 'active_group': active_group, "tag_info": tag_info, 
 						"member_info": member_info, 'is_member': is_member}
 		else:
@@ -580,7 +579,6 @@ def create_group(request):
 		mod_edit_wl_bl = request.POST['mod_edit_wl_bl'] == 'true'
 		mod_rules = request.POST['mod_rules']
 		auto_approve = request.POST['auto_approve'] =='true'
-		logger.debug('create group')
 		res = engine.main.create_group(request.POST['group_name'], request.POST['group_desc'], public, attach, send_rejected, store_rejected, mod_edit_wl_bl, mod_rules, auto_approve, user)
 		return HttpResponse(json.dumps(res), content_type="application/json")
 	except Exception, e:

--- a/engine/constants.py
+++ b/engine/constants.py
@@ -6,7 +6,7 @@ msg_code={
 	'USER_DOES_NOT_EXIST': 'User %s does not exist in Murmur system.',
 	'PRIVILEGE_ERROR': 'Do not have the required privileges',
 	'NOT_MEMBER': 'Not a member of this Group',
-	'NOT_MEMBERS': '%s cannot be added sicne they are not a member of this group',
+	'NOT_MEMBERS': '%s cannot be added since they are not a member of this group',
 	'DUPLICATE_ERROR': 'Name already exists',
 	'GROUP_NOT_FOUND_ERROR': 'Group not found',
 	'POST_NOT_FOUND_ERROR': 'Post not found',

--- a/engine/main.py
+++ b/engine/main.py
@@ -894,6 +894,7 @@ def load_thread(t, user=None, member=None):
         for attachment in Attachment.objects.filter(msg_id=p.msg_id):
             url = "attachment/" + attachment.hash_filename
             attachments.append((attachment.true_filename, url))
+            
         post_dict = {
                     'id': str(p.id),
                     'msg_id': p.msg_id, 

--- a/engine/main.py
+++ b/engine/main.py
@@ -257,6 +257,7 @@ def edit_donotsend_table(group_name, toDelete, user):
 
 def create_group(group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit_wl_bl, mod_rules, auto_approve, requester):
     res = {'status':False}
+
     # friendly name has spaces
     friendly_name = group_name.replace('_',' ')
     
@@ -789,7 +790,6 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
                 for attachment in Attachment.objects.filter(msg_id=p.msg_id):
                     url = "attachment/" + attachment.hash_filename
                     attachments.append((attachment.true_filename, url))
-            
             
             #text = clean(p.post, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES)
             text = fix_html_and_img_srcs(p.msg_id, p.post, include_line_break = False)

--- a/engine/main.py
+++ b/engine/main.py
@@ -255,7 +255,9 @@ def edit_donotsend_table(group_name, toDelete, user):
 
 def create_group(group_name, group_desc, public, attach, send_rejected, store_rejected, mod_edit_wl_bl, mod_rules, auto_approve, requester):
     res = {'status':False}
-    
+    # friendly name has spaces
+    friendly_name = group_name.replace('_',' ')
+
     
     if not re.match('^[\w-]+$', group_name) is not None:
         res['code'] = msg_code['INCORRECT_GROUP_NAME']
@@ -274,7 +276,7 @@ def create_group(group_name, group_desc, public, attach, send_rejected, store_re
         res['code'] = msg_code['DUPLICATE_ERROR']
         
     except Group.DoesNotExist:
-        group = Group(name=group_name, active=True, public=public, allow_attachments=attach, send_rejected_tagged=send_rejected, 
+        group = Group(name=group_name, friendly_name=friendly_name, active=True, public=public, allow_attachments=attach, send_rejected_tagged=send_rejected, 
             show_rejected_site=store_rejected, description=group_desc, mod_rules=mod_rules, mod_edit_wl_bl=mod_edit_wl_bl,
             auto_approve_after_first=auto_approve)
         group.save()

--- a/engine/main.py
+++ b/engine/main.py
@@ -790,6 +790,7 @@ def list_posts_page(threads, group, res, user=None, format_datetime=True, return
                     url = "attachment/" + attachment.hash_filename
                     attachments.append((attachment.true_filename, url))
             
+            
             #text = clean(p.post, tags=ALLOWED_TAGS, attributes=ALLOWED_ATTRIBUTES, styles=ALLOWED_STYLES)
             text = fix_html_and_img_srcs(p.msg_id, p.post, include_line_break = False)
             if text_limit:

--- a/engine/main.py
+++ b/engine/main.py
@@ -36,7 +36,7 @@ def list_groups(user=None):
                 mod = membergroup[0].moderator
             
         groups.append({'name':g.name, 
-                       'friendly_name':g.friendly_name, # should i do this
+                       'friendly_name':g.friendly_name, 
                        'desc': escape(g.description),  
                        'member': member, 
                        'admin': admin, 
@@ -259,8 +259,6 @@ def create_group(group_name, group_desc, public, attach, send_rejected, store_re
     res = {'status':False}
     # friendly name has spaces
     friendly_name = group_name.replace('_',' ')
-    logger.debug(group_name)
-
     
     if not re.match('^[\w-]+$', group_name) is not None:
         res['code'] = msg_code['INCORRECT_GROUP_NAME']
@@ -895,7 +893,6 @@ def load_thread(t, user=None, member=None):
         for attachment in Attachment.objects.filter(msg_id=p.msg_id):
             url = "attachment/" + attachment.hash_filename
             attachments.append((attachment.true_filename, url))
-        logger.debug(p.timestamp)
         post_dict = {
                     'id': str(p.id),
                     'msg_id': p.msg_id, 
@@ -906,7 +903,7 @@ def load_thread(t, user=None, member=None):
                     'liked': user_liked,
                     'subject': escape(p.subject), 
                     'text' : fix_html_and_img_srcs(p.msg_id, p.post),
-                    'timestamp': p.timestamp,
+                    'timestamp': format_date_time(p.timestamp),
                     'attachments': attachments,
                     'verified': p.verified_sender,
                     'who_moderated' : p.who_moderated,
@@ -1086,7 +1083,7 @@ def _create_post(group, subject, message_text, user, sender_addr, msg_id, verifi
     
     return p, thread, recipients, tags, tag_objs
 
-def insert_post_web(group_name, subject, message_text, user, friendly_name=''):
+def insert_post_web(group_name, subject, message_text, user):
     res = {'status':False}
     thread = None
 

--- a/http_handler/static/javascript/add_donotsend.js
+++ b/http_handler/static/javascript/add_donotsend.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 
-    var group_name = $.trim($("#group-name").text()),
+    var group_name = $.trim($("#group-name").text().replaceAll(' ','_')),
         btn_add_dissimulate = $("#btn-add-dissimulate");
 
 

--- a/http_handler/static/javascript/add_members.js
+++ b/http_handler/static/javascript/add_members.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
     var website = $("#website-name").text();
-    var group_name = $.trim($("#group-name").text());
+    var group_name = $.trim($("#friendly-name").text().replace(' ','_'));
 
     var btn_add_members = $("#btn-add-members");
 

--- a/http_handler/static/javascript/create_group.js
+++ b/http_handler/static/javascript/create_group.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
     btn_create_group.click(function() {
 
         var params = {
-            'group_name' : $("#group-name").val(),
+            'group_name' : $("#group-name").val().replaceAll(' ','_'),
             'group_desc' : $("#group-description").val(),
             'send_rejected_tagged' : true,
             'store_rejected' : true,

--- a/http_handler/static/javascript/edit_group_info.js
+++ b/http_handler/static/javascript/edit_group_info.js
@@ -12,7 +12,8 @@ $(document).ready(function() {
     btn_save_settings.click(function() {
         var params = {
             'old_group_name': old_group_name,
-            'new_group_name': $("#group-name").val(),
+            'new_group_name': $("#group-name").val().replaceAll(' ','_'),
+            'new_friendly_name': $("#group-name").val(),
             'group_desc': $("#group-description").val(),
             'attach': $('input[name=attach]:checked', "#group-form").val(),
         }

--- a/http_handler/static/javascript/murmur/add_list.js
+++ b/http_handler/static/javascript/murmur/add_list.js
@@ -1,6 +1,6 @@
 $(document).ready(function(){
 	
-	var group_name = $.trim($("#group-name").text());
+	var group_name = $.trim($("#group-name").text().replaceAll(' ','_'));
 	var user_name = $.trim($("#user-name").text());
 	var btn_add_list = $("#btn-add-list");
 	

--- a/http_handler/static/javascript/murmur/create_post.js
+++ b/http_handler/static/javascript/murmur/create_post.js
@@ -10,7 +10,8 @@ $(document).ready(function(){
 		function(params){
 			params.msg_text = CKEDITOR.instances['new-post-text'].getData();
             params.subject = $("#new-post-subject").val();
-            params.group_name = $("#new-post-to").text();
+			params.group_name = $("#group-name").text().replaceAll(' ','_');
+			params.friendly_name = $("#group-name").text();
             params.poster_email = params.requester_email;
 			$.post('/insert_post', params, 
 				function(res){

--- a/http_handler/static/javascript/murmur/group_page.js
+++ b/http_handler/static/javascript/murmur/group_page.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
 
 	var user_name = $.trim($('#user_email').text()),
-		group_name = $.trim($("#friendly-name").text().replaceAll(' ','_')),
+		group_name = $.trim($("#group-name").text().replaceAll(' ','_')),
 		member = $.trim($(".member").text()) == "Member",
 		admin = $.trim($(".admin").text()) == "Admin",
 		mod = $.trim($(".mod").text()) == "Mod",

--- a/http_handler/static/javascript/murmur/group_page.js
+++ b/http_handler/static/javascript/murmur/group_page.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
 
 	var user_name = $.trim($('#user_email').text()),
-		group_name = $.trim($("#group-name").text()),
+		group_name = $.trim($("#friendly-name").text().replaceAll(' ','_')),
 		member = $.trim($(".member").text()) == "Member",
 		admin = $.trim($(".admin").text()) == "Admin",
 		mod = $.trim($(".mod").text()) == "Mod",

--- a/http_handler/static/javascript/murmur/my_group_settings.js
+++ b/http_handler/static/javascript/murmur/my_group_settings.js
@@ -1,7 +1,7 @@
 $(document).ready(function(){
 	
 	var user_name = $.trim($('#user_email').text());
-	var group_name = $.trim($("#group-name").text());
+	var group_name = $.trim($("#group_name").text().replaceAll(' ','_'));
 	
 	var btn_add_dissimulate = $("#btn-add-dissimulate"),
 		btn_delete_dissimulate = $("#btn-delete-dissimulate");

--- a/schema/models.py
+++ b/schema/models.py
@@ -210,7 +210,10 @@ class ForwardingList(models.Model):
 
 class Group(models.Model):
 	id = models.AutoField(primary_key=True)
+	# if the user inputs a name with spaces, this name attribute will replace the spaces with underscores
 	name = models.CharField(max_length=20, unique=True)
+	# if the user inputs a name with spaces, this friendly_name attribute will have the spaces
+	friendly_name = models.CharField(default='',max_length=20)
 	description = models.CharField(max_length=140)
 	public = models.BooleanField(default=True)
 	active = models.BooleanField(default=True)


### PR DESCRIPTION
Previously, when a person tried to input a group name with spaces, it would not work. Now with this change, this is possible. If a person writes a name with spaces, the name attribute in the Group model will replace the spaces with underscores. Meanwhile, the friendly_name attribute will keep the spaces and use this to display the name with the spaces in the frontend. 